### PR TITLE
Update Move2DControl.cs

### DIFF
--- a/LaserGRBL/UserControls/Move2DControl.cs
+++ b/LaserGRBL/UserControls/Move2DControl.cs
@@ -409,6 +409,7 @@ namespace LaserGRBL.UserControls
 						{
 							SpeedValue= ((SpeedPercentZone)z).Speed;
 						}
+						return;
 					}
 				}
 			}


### PR DESCRIPTION
Correction of slight difference of "under mouse" zone between  move/preview and click zone.

click zone of the trackbar have a minimum size of 5px. so ther is some overlapp when the control is small

for the preview, i stop at the first hit, in the click function, i was not. (preview == "first hit", click == "last one")