### PR TITLE
Smoothieware - gCode laser power 

### DIFF
--- a/LaserGRBL/RasterConverter/ImageProcessor.cs
+++ b/LaserGRBL/RasterConverter/ImageProcessor.cs
@@ -870,6 +870,7 @@ namespace LaserGRBL.RasterConverter
 						conf.oY = TargetOffset.Y;
 						conf.borderSpeed = BorderSpeed;
 						conf.pwm = (bool)Settings.GetObject("Support Hardware PWM", true);
+						conf.firmwareType = (Firmware)Settings.GetObject("Firmware Type", Firmware.Grbl);
 
 						if (SelectedTool == ImageProcessor.Tool.Line2Line || SelectedTool == ImageProcessor.Tool.Dithering)
 							mCore.LoadedFile.LoadImageL2L(bmp, mFileName, conf, mAppend);


### PR DESCRIPTION
Hello,

  Thank you for the work you have done. Your software is great !
  For smoothieware firmware : laser power must be defined with a value between 0.00 and 1.00 (ie G01 X123 S0.45). Your soft defined a value between 0 and 255 . ( http://smoothieware.org/laser#testing )
  Pull request change this.

Regards,

Guillaume Rico