### PR TITLE
Adding overflow prevention to BezierTools.cs.

### DIFF
--- a/LaserGRBL/SvgConverter/BezierTools.cs
+++ b/LaserGRBL/SvgConverter/BezierTools.cs
@@ -91,6 +91,11 @@ namespace LaserGRBL.SvgConverter
             var c2 = c - max_distance_above;
 
             var det = a1 * b2 - a2 * b1;
+            if (det == 0)
+            {
+                return 0; // Otherwise the intercepts would blow up to +/- Inf.
+            }
+
             var dInv = 1.0 / det;
 
             var intercept_1 = (b1 * c2 - b2 * c1) * dInv;


### PR DESCRIPTION
Background: I ran into a stack overflow error while trying to load an SVG I made in Inkscape. For the life of me, I couldn't figure out which nodes were causing the problem so eventually I checked out this project and traced the error back to `BezierTools.cs`. It wasn't watching for when control points get so close together that no more subdivision would be meaningful. 

I believe the code I've added says "the error is zero when the distance between control points has reached the limit of floating point precision." But I'm not 100%. It does solve my issue, though, and it doesn't seem to introduce any others. :-)

The attached SVG demonstrates the issue.

[bezier-bug-demo.zip](https://github.com/arkypita/LaserGRBL/files/7272721/bezier-bug-demo.zip)

Thanks!
