### PR TITLE
build: fix build under mono msbuild

### DIFF
--- a/LaserGRBL/LaserGRBL.csproj
+++ b/LaserGRBL/LaserGRBL.csproj
@@ -80,6 +80,9 @@
     <BaseIntermediateOutputPath>obj\</BaseIntermediateOutputPath>
     <StartAction>Project</StartAction>
   </PropertyGroup>
+  <PropertyGroup Condition="$([MSBuild]::IsOSPlatform('Windows'))">
+    <DefineConstants>OS_WINDOWS</DefineConstants>
+  </PropertyGroup>
   <PropertyGroup>
     <ForceDesignerDPIUnaware>true</ForceDesignerDPIUnaware>
   </PropertyGroup>

--- a/LaserGRBL/LaserGRBL.csproj
+++ b/LaserGRBL/LaserGRBL.csproj
@@ -52,7 +52,6 @@
     <WarningLevel>4</WarningLevel>
     <GenerateSerializationAssemblies>Off</GenerateSerializationAssemblies>
     <UseVSHostingProcess>false</UseVSHostingProcess>
-    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
     <CodeAnalysisIgnoreGeneratedCode>false</CodeAnalysisIgnoreGeneratedCode>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
@@ -102,7 +101,7 @@
     <Reference Include="System.Security" />
     <Reference Include="System.Web" />
     <Reference Include="System.Windows.Forms" />
-    <Reference Include="System.XML" />
+    <Reference Include="System.Xml" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="WindowsBase" />
   </ItemGroup>
@@ -981,7 +980,7 @@
     <Compile Include="UserControls\MyPictureBox.cs">
       <SubType>Component</SubType>
     </Compile>
-    <Compile Include="UserControls\MyPictureBox.designer.cs">
+    <Compile Include="UserControls\MyPictureBox.Designer.cs">
       <DependentUpon>MyPictureBox.cs</DependentUpon>
     </Compile>
     <Compile Include="UserControls\NumericInput\ColoredBorderControl.cs">

--- a/LaserGRBL/PreviewForm.cs
+++ b/LaserGRBL/PreviewForm.cs
@@ -9,7 +9,9 @@ using LaserGRBL.UserControls;
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
+#if OS_WINDOWS
 using System.Diagnostics.Eventing.Reader;
+#endif
 using System.Drawing;
 using System.Windows.Forms;
 

--- a/LaserGRBL/Tools/HiResTimer.cs
+++ b/LaserGRBL/Tools/HiResTimer.cs
@@ -26,6 +26,7 @@ namespace Tools
 	// sbagliata di molto. Abbiamo infatti notato su UNA macchina (portatile DELL VOSTRO 3750 - i5-2450M w7-64bit) che la funzione QPC può dare
 	// delle tempistiche incoerenti con la relativa QPF, cambiando la sua velocità anche in corso di esecuzione del programma, senza variazioni di QPF
 	//
+#if OS_WINDOWS
 	public static class HiResTimer
 	{
 
@@ -311,6 +312,29 @@ namespace Tools
 		}
 
 	}
+#else
+	// Non-Windows platforms, use generic
+	public static class HiResTimer
+	{
+		private const long NANO_IN_MILLI = 1000 * 1000;
+		private static Stopwatch watch = new Stopwatch();
+
+		static HiResTimer() //costruttore static, viene chiamato prima del primo utilizzo della classe
+		{watch.Start();}
+
+		public static long TotalMilliseconds
+		{ get { return TotalNano / NANO_IN_MILLI; } }
+
+		public static long TotalNano
+		{
+			get
+			{
+				return (long)((double)watch.ElapsedTicks / (double)Stopwatch.Frequency * 1000000000.0);
+			}
+		}
+
+	}
+#endif
 
 
 	public class Utils


### PR DESCRIPTION
* Correct System.XML reference to System.Xml
* Drop legacy CodeAnalysisRuleSet (recommended per microsoft)
  https://docs.microsoft.com/en-us/visualstudio/code-quality/migrate-from-legacy-analysis-to-net-analyzers
* Fix case of MyPictureBox.Designer.cs