### PR TITLE
Fix SVG Viewbox positioning

### DIFF
--- a/LaserGRBL/SvgConverter/GCodeFromSVG.cs
+++ b/LaserGRBL/SvgConverter/GCodeFromSVG.cs
@@ -183,7 +183,7 @@ namespace LaserGRBL.SvgConverter
 				{
 					scaledError = scale * svgWidthPx / vbWidth;
 					tmp.M11 = scaledError;
-					tmp.OffsetX = vbOffX * scale;   // svgWidthUnit / vbWidth;
+					tmp.OffsetX = (vbOffX * svgWidthPx / vbWidth )  * scale;  
 				}
 			}
 
@@ -202,7 +202,7 @@ namespace LaserGRBL.SvgConverter
 				if (vbHeight > 0)
 				{
 					tmp.M22 = -scale * svgHeightPx / vbHeight;
-					tmp.OffsetY = -vbOffY * svgHeightPx / vbHeight + (svgHeightPx * scale);
+					tmp.OffsetY = (-vbOffY * svgHeightPx / vbHeight + svgHeightPx) * scale;
 				}
 			}
 


### PR DESCRIPTION
After this changes the images produced by OpenSCAD are always displayed at the origin of XY-Axis (with an error of 0..1 mm due to the rounding error of the ViewBox that is in full mm) .
The images produced by Inscape are displayed correctly too.