### PR TITLE
feat: add option to switch line endings to LF

### DIFF
--- a/LaserGRBL/Core/GrblCore.cs
+++ b/LaserGRBL/Core/GrblCore.cs
@@ -752,7 +752,7 @@ namespace LaserGRBL
 			return null;
 		}
 
-		public void SaveProgram(Form parent, bool header, bool footer, bool between, int cycles)
+		public void SaveProgram(Form parent, bool header, bool footer, bool between, int cycles, bool useLFLineEndings)
 		{
 			if (HasProgram)
 			{
@@ -787,7 +787,7 @@ namespace LaserGRBL
 				}
 
                 if (filename != null)
-					file.SaveGCODE(filename, header, footer, between, cycles, this);
+					file.SaveGCODE(filename, header, footer, between, cycles, useLFLineEndings, this);
 			}
 		}
 

--- a/LaserGRBL/GrblFile.cs
+++ b/LaserGRBL/GrblFile.cs
@@ -41,12 +41,15 @@ namespace LaserGRBL
 			mRange.UpdateXYRange(new GrblCommand.Element('X', x1), new GrblCommand.Element('Y', y1), false);
 		}
 
-		public void SaveGCODE(string filename, bool header, bool footer, bool between, int cycles, GrblCore core)
+		public void SaveGCODE(string filename, bool header, bool footer, bool between, int cycles, bool useLFLineEndings, GrblCore core)
 		{
 			try
 			{
 				using (System.IO.StreamWriter sw = new System.IO.StreamWriter(filename))
 				{
+					if (useLFLineEndings)
+						sw.NewLine = "\n";
+
 					if (header)
 						EvaluateAddLines(core, sw, Settings.GetObject("GCode.CustomHeader", GrblCore.GCODE_STD_HEADER));
 

--- a/LaserGRBL/HotKeysManager.cs
+++ b/LaserGRBL/HotKeysManager.cs
@@ -233,7 +233,7 @@ namespace LaserGRBL
 				case HotKey.Actions.ReopenLastFile:
 					mCore.ReOpenFile(Application.OpenForms[0]); break;
 				case HotKey.Actions.SaveFile:
-					mCore.SaveProgram(parent, false, false, false, 1); break;
+					mCore.SaveProgram(parent, false, false, false, 1, false); break;
 				case HotKey.Actions.ExecuteFile:
 					mCore.RunProgram(parent); break;
 				case HotKey.Actions.AbortFile:

--- a/LaserGRBL/MainForm.cs
+++ b/LaserGRBL/MainForm.cs
@@ -493,7 +493,7 @@ namespace LaserGRBL
 		}
 		void MnSaveProgramClick(object sender, EventArgs e)
 		{
-			Core.SaveProgram(this, false, false, false, 1);
+			Core.SaveProgram(this, false, false, false, 1, false);
 		}
 
 		private void MnAdvancedSave_Click(object sender, EventArgs e)

--- a/LaserGRBL/SaveOptionForm.Designer.cs
+++ b/LaserGRBL/SaveOptionForm.Designer.cs
@@ -28,132 +28,141 @@
 		/// </summary>
 		private void InitializeComponent()
 		{
-			System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(SaveOptionForm));
-			this.tableLayoutPanel1 = new System.Windows.Forms.TableLayoutPanel();
-			this.label2 = new System.Windows.Forms.Label();
-			this.tableLayoutPanel3 = new System.Windows.Forms.TableLayoutPanel();
-			this.BtnSave = new System.Windows.Forms.Button();
-			this.groupBox1 = new System.Windows.Forms.GroupBox();
-			this.tableLayoutPanel2 = new System.Windows.Forms.TableLayoutPanel();
-			this.CBHeader = new System.Windows.Forms.CheckBox();
-			this.CBFooter = new System.Windows.Forms.CheckBox();
-			this.UDCount = new System.Windows.Forms.NumericUpDown();
-			this.label1 = new System.Windows.Forms.Label();
-			this.CBBetween = new System.Windows.Forms.CheckBox();
-			this.tableLayoutPanel1.SuspendLayout();
-			this.tableLayoutPanel3.SuspendLayout();
-			this.groupBox1.SuspendLayout();
-			this.tableLayoutPanel2.SuspendLayout();
-			((System.ComponentModel.ISupportInitialize)(this.UDCount)).BeginInit();
-			this.SuspendLayout();
-			// 
-			// tableLayoutPanel1
-			// 
-			resources.ApplyResources(this.tableLayoutPanel1, "tableLayoutPanel1");
-			this.tableLayoutPanel1.Controls.Add(this.groupBox1, 0, 0);
-			this.tableLayoutPanel1.Controls.Add(this.label2, 0, 1);
-			this.tableLayoutPanel1.Controls.Add(this.tableLayoutPanel3, 0, 2);
-			this.tableLayoutPanel1.Name = "tableLayoutPanel1";
-			// 
-			// label2
-			// 
-			resources.ApplyResources(this.label2, "label2");
-			this.label2.Name = "label2";
-			// 
-			// tableLayoutPanel3
-			// 
-			resources.ApplyResources(this.tableLayoutPanel3, "tableLayoutPanel3");
-			this.tableLayoutPanel3.Controls.Add(this.BtnSave, 1, 0);
-			this.tableLayoutPanel3.Name = "tableLayoutPanel3";
-			// 
-			// BtnSave
-			// 
-			this.BtnSave.DialogResult = System.Windows.Forms.DialogResult.OK;
-			resources.ApplyResources(this.BtnSave, "BtnSave");
-			this.BtnSave.Name = "BtnSave";
-			this.BtnSave.UseVisualStyleBackColor = true;
-			// 
-			// groupBox1
-			// 
-			resources.ApplyResources(this.groupBox1, "groupBox1");
-			this.groupBox1.Controls.Add(this.tableLayoutPanel2);
-			this.groupBox1.Name = "groupBox1";
-			this.groupBox1.TabStop = false;
-			// 
-			// tableLayoutPanel2
-			// 
-			resources.ApplyResources(this.tableLayoutPanel2, "tableLayoutPanel2");
-			this.tableLayoutPanel2.Controls.Add(this.CBHeader, 0, 0);
-			this.tableLayoutPanel2.Controls.Add(this.CBFooter, 0, 2);
-			this.tableLayoutPanel2.Controls.Add(this.UDCount, 1, 1);
-			this.tableLayoutPanel2.Controls.Add(this.label1, 0, 1);
-			this.tableLayoutPanel2.Controls.Add(this.CBBetween, 2, 1);
-			this.tableLayoutPanel2.Name = "tableLayoutPanel2";
-			// 
-			// CBHeader
-			// 
-			resources.ApplyResources(this.CBHeader, "CBHeader");
-			this.CBHeader.Checked = true;
-			this.CBHeader.CheckState = System.Windows.Forms.CheckState.Checked;
-			this.tableLayoutPanel2.SetColumnSpan(this.CBHeader, 2);
-			this.CBHeader.Name = "CBHeader";
-			this.CBHeader.UseVisualStyleBackColor = true;
-			// 
-			// CBFooter
-			// 
-			resources.ApplyResources(this.CBFooter, "CBFooter");
-			this.CBFooter.Checked = true;
-			this.CBFooter.CheckState = System.Windows.Forms.CheckState.Checked;
-			this.tableLayoutPanel2.SetColumnSpan(this.CBFooter, 2);
-			this.CBFooter.Name = "CBFooter";
-			this.CBFooter.UseVisualStyleBackColor = true;
-			// 
-			// UDCount
-			// 
-			resources.ApplyResources(this.UDCount, "UDCount");
-			this.UDCount.Minimum = new decimal(new int[] {
+            System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(SaveOptionForm));
+            this.tableLayoutPanel1 = new System.Windows.Forms.TableLayoutPanel();
+            this.groupBox1 = new System.Windows.Forms.GroupBox();
+            this.tableLayoutPanel2 = new System.Windows.Forms.TableLayoutPanel();
+            this.CBLFLineEndings = new System.Windows.Forms.CheckBox();
+            this.CBHeader = new System.Windows.Forms.CheckBox();
+            this.CBFooter = new System.Windows.Forms.CheckBox();
+            this.UDCount = new System.Windows.Forms.NumericUpDown();
+            this.label1 = new System.Windows.Forms.Label();
+            this.CBBetween = new System.Windows.Forms.CheckBox();
+            this.label2 = new System.Windows.Forms.Label();
+            this.tableLayoutPanel3 = new System.Windows.Forms.TableLayoutPanel();
+            this.BtnSave = new System.Windows.Forms.Button();
+            this.tableLayoutPanel1.SuspendLayout();
+            this.groupBox1.SuspendLayout();
+            this.tableLayoutPanel2.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.UDCount)).BeginInit();
+            this.tableLayoutPanel3.SuspendLayout();
+            this.SuspendLayout();
+            // 
+            // tableLayoutPanel1
+            // 
+            resources.ApplyResources(this.tableLayoutPanel1, "tableLayoutPanel1");
+            this.tableLayoutPanel1.Controls.Add(this.groupBox1, 0, 0);
+            this.tableLayoutPanel1.Controls.Add(this.label2, 0, 1);
+            this.tableLayoutPanel1.Controls.Add(this.tableLayoutPanel3, 0, 2);
+            this.tableLayoutPanel1.Name = "tableLayoutPanel1";
+            // 
+            // groupBox1
+            // 
+            resources.ApplyResources(this.groupBox1, "groupBox1");
+            this.groupBox1.Controls.Add(this.tableLayoutPanel2);
+            this.groupBox1.Name = "groupBox1";
+            this.groupBox1.TabStop = false;
+            // 
+            // tableLayoutPanel2
+            // 
+            resources.ApplyResources(this.tableLayoutPanel2, "tableLayoutPanel2");
+            this.tableLayoutPanel2.Controls.Add(this.CBLFLineEndings, 0, 3);
+            this.tableLayoutPanel2.Controls.Add(this.CBHeader, 0, 0);
+            this.tableLayoutPanel2.Controls.Add(this.CBFooter, 0, 2);
+            this.tableLayoutPanel2.Controls.Add(this.UDCount, 1, 1);
+            this.tableLayoutPanel2.Controls.Add(this.label1, 0, 1);
+            this.tableLayoutPanel2.Controls.Add(this.CBBetween, 2, 1);
+            this.tableLayoutPanel2.Name = "tableLayoutPanel2";
+            // 
+            // CBLFLineEndings
+            // 
+            resources.ApplyResources(this.CBLFLineEndings, "CBLFLineEndings");
+            this.tableLayoutPanel2.SetColumnSpan(this.CBLFLineEndings, 2);
+            this.CBLFLineEndings.Name = "CBLFLineEndings";
+            this.CBLFLineEndings.UseVisualStyleBackColor = true;
+            // 
+            // CBHeader
+            // 
+            resources.ApplyResources(this.CBHeader, "CBHeader");
+            this.CBHeader.Checked = true;
+            this.CBHeader.CheckState = System.Windows.Forms.CheckState.Checked;
+            this.tableLayoutPanel2.SetColumnSpan(this.CBHeader, 2);
+            this.CBHeader.Name = "CBHeader";
+            this.CBHeader.UseVisualStyleBackColor = true;
+            // 
+            // CBFooter
+            // 
+            resources.ApplyResources(this.CBFooter, "CBFooter");
+            this.CBFooter.Checked = true;
+            this.CBFooter.CheckState = System.Windows.Forms.CheckState.Checked;
+            this.tableLayoutPanel2.SetColumnSpan(this.CBFooter, 2);
+            this.CBFooter.Name = "CBFooter";
+            this.CBFooter.UseVisualStyleBackColor = true;
+            // 
+            // UDCount
+            // 
+            resources.ApplyResources(this.UDCount, "UDCount");
+            this.UDCount.Minimum = new decimal(new int[] {
             1,
             0,
             0,
             0});
-			this.UDCount.Name = "UDCount";
-			this.UDCount.Value = new decimal(new int[] {
+            this.UDCount.Name = "UDCount";
+            this.UDCount.Value = new decimal(new int[] {
             1,
             0,
             0,
             0});
-			// 
-			// label1
-			// 
-			resources.ApplyResources(this.label1, "label1");
-			this.label1.Name = "label1";
-			// 
-			// CBBetween
-			// 
-			resources.ApplyResources(this.CBBetween, "CBBetween");
-			this.CBBetween.Checked = true;
-			this.CBBetween.CheckState = System.Windows.Forms.CheckState.Checked;
-			this.CBBetween.Name = "CBBetween";
-			this.CBBetween.UseVisualStyleBackColor = true;
-			// 
-			// SaveOptionForm
-			// 
-			resources.ApplyResources(this, "$this");
-			this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-			this.Controls.Add(this.tableLayoutPanel1);
-			this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedSingle;
-			this.MaximizeBox = false;
-			this.MinimizeBox = false;
-			this.Name = "SaveOptionForm";
-			this.tableLayoutPanel1.ResumeLayout(false);
-			this.tableLayoutPanel1.PerformLayout();
-			this.tableLayoutPanel3.ResumeLayout(false);
-			this.groupBox1.ResumeLayout(false);
-			this.groupBox1.PerformLayout();
-			this.tableLayoutPanel2.ResumeLayout(false);
-			this.tableLayoutPanel2.PerformLayout();
-			((System.ComponentModel.ISupportInitialize)(this.UDCount)).EndInit();
-			this.ResumeLayout(false);
+            // 
+            // label1
+            // 
+            resources.ApplyResources(this.label1, "label1");
+            this.label1.Name = "label1";
+            // 
+            // CBBetween
+            // 
+            resources.ApplyResources(this.CBBetween, "CBBetween");
+            this.CBBetween.Checked = true;
+            this.CBBetween.CheckState = System.Windows.Forms.CheckState.Checked;
+            this.CBBetween.Name = "CBBetween";
+            this.CBBetween.UseVisualStyleBackColor = true;
+            // 
+            // label2
+            // 
+            resources.ApplyResources(this.label2, "label2");
+            this.label2.Name = "label2";
+            // 
+            // tableLayoutPanel3
+            // 
+            resources.ApplyResources(this.tableLayoutPanel3, "tableLayoutPanel3");
+            this.tableLayoutPanel3.Controls.Add(this.BtnSave, 1, 0);
+            this.tableLayoutPanel3.Name = "tableLayoutPanel3";
+            // 
+            // BtnSave
+            // 
+            this.BtnSave.DialogResult = System.Windows.Forms.DialogResult.OK;
+            resources.ApplyResources(this.BtnSave, "BtnSave");
+            this.BtnSave.Name = "BtnSave";
+            this.BtnSave.UseVisualStyleBackColor = true;
+            // 
+            // SaveOptionForm
+            // 
+            resources.ApplyResources(this, "$this");
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.Controls.Add(this.tableLayoutPanel1);
+            this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedSingle;
+            this.MaximizeBox = false;
+            this.MinimizeBox = false;
+            this.Name = "SaveOptionForm";
+            this.tableLayoutPanel1.ResumeLayout(false);
+            this.tableLayoutPanel1.PerformLayout();
+            this.groupBox1.ResumeLayout(false);
+            this.groupBox1.PerformLayout();
+            this.tableLayoutPanel2.ResumeLayout(false);
+            this.tableLayoutPanel2.PerformLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.UDCount)).EndInit();
+            this.tableLayoutPanel3.ResumeLayout(false);
+            this.ResumeLayout(false);
 
 		}
 
@@ -170,5 +179,6 @@
 		private System.Windows.Forms.NumericUpDown UDCount;
 		private System.Windows.Forms.Label label1;
 		private System.Windows.Forms.CheckBox CBBetween;
-	}
+        private System.Windows.Forms.CheckBox CBLFLineEndings;
+    }
 }

--- a/LaserGRBL/SaveOptionForm.cs
+++ b/LaserGRBL/SaveOptionForm.cs
@@ -21,7 +21,7 @@ namespace LaserGRBL
 			using (SaveOptionForm f = new SaveOptionForm())
 			{
 				if (f.ShowDialog(parent) == DialogResult.OK)
-					core.SaveProgram(parent, f.CBHeader.Checked, f.CBFooter.Checked, f.CBBetween.Checked, (int)f.UDCount.Value);
+					core.SaveProgram(parent, f.CBHeader.Checked, f.CBFooter.Checked, f.CBBetween.Checked, (int)f.UDCount.Value, f.CBLFLineEndings.Checked);
 			}
 		}
 

--- a/LaserGRBL/SaveOptionForm.resx
+++ b/LaserGRBL/SaveOptionForm.resx
@@ -112,19 +112,19 @@
     <value>2.0</value>
   </resheader>
   <resheader name="reader">
-    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <resheader name="writer">
-    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <assembly alias="mscorlib" name="mscorlib, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <assembly alias="mscorlib" name="mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="tableLayoutPanel1.ColumnCount" type="System.Int32, mscorlib">
     <value>1</value>
   </data>
   <data name="groupBox1.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
-  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="groupBox1.AutoSizeMode" type="System.Windows.Forms.AutoSizeMode, System.Windows.Forms">
     <value>GrowAndShrink</value>
   </data>
@@ -133,6 +133,43 @@
   </data>
   <data name="tableLayoutPanel2.ColumnCount" type="System.Int32, mscorlib">
     <value>3</value>
+  </data>
+  <data name="CBLFLineEndings.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Left</value>
+  </data>
+  <data name="CBLFLineEndings.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="CBLFLineEndings.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+  <data name="CBLFLineEndings.Location" type="System.Drawing.Point, System.Drawing">
+    <value>4, 94</value>
+  </data>
+  <data name="CBLFLineEndings.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
+  </data>
+  <data name="CBLFLineEndings.Size" type="System.Drawing.Size, System.Drawing">
+    <value>155, 21</value>
+  </data>
+  <data name="CBLFLineEndings.TabIndex" type="System.Int32, mscorlib">
+    <value>5</value>
+  </data>
+  <data name="CBLFLineEndings.Text" xml:space="preserve">
+    <value>Use LF line endings</value>
+  </data>
+  <data name="&gt;&gt;CBLFLineEndings.Name" xml:space="preserve">
+    <value>CBLFLineEndings</value>
+  </data>
+  <data name="&gt;&gt;CBLFLineEndings.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;CBLFLineEndings.Parent" xml:space="preserve">
+    <value>tableLayoutPanel2</value>
+  </data>
+  <data name="&gt;&gt;CBLFLineEndings.ZOrder" xml:space="preserve">
+    <value>0</value>
   </data>
   <data name="CBHeader.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Left</value>
@@ -143,12 +180,14 @@
   <data name="CBHeader.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
   </data>
-  <assembly alias="System.Drawing" name="System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   <data name="CBHeader.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 3</value>
+    <value>4, 4</value>
+  </data>
+  <data name="CBHeader.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="CBHeader.Size" type="System.Drawing.Size, System.Drawing">
-    <value>94, 17</value>
+    <value>121, 21</value>
   </data>
   <data name="CBHeader.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -160,13 +199,13 @@
     <value>CBHeader</value>
   </data>
   <data name="&gt;&gt;CBHeader.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;CBHeader.Parent" xml:space="preserve">
     <value>tableLayoutPanel2</value>
   </data>
   <data name="&gt;&gt;CBHeader.ZOrder" xml:space="preserve">
-    <value>0</value>
+    <value>1</value>
   </data>
   <data name="CBFooter.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Left</value>
@@ -178,10 +217,13 @@
     <value>NoControl</value>
   </data>
   <data name="CBFooter.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 52</value>
+    <value>4, 65</value>
+  </data>
+  <data name="CBFooter.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="CBFooter.Size" type="System.Drawing.Size, System.Drawing">
-    <value>89, 17</value>
+    <value>115, 21</value>
   </data>
   <data name="CBFooter.TabIndex" type="System.Int32, mscorlib">
     <value>2</value>
@@ -193,22 +235,25 @@
     <value>CBFooter</value>
   </data>
   <data name="&gt;&gt;CBFooter.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;CBFooter.Parent" xml:space="preserve">
     <value>tableLayoutPanel2</value>
   </data>
   <data name="&gt;&gt;CBFooter.ZOrder" xml:space="preserve">
-    <value>1</value>
+    <value>2</value>
   </data>
   <data name="UDCount.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Left</value>
   </data>
   <data name="UDCount.Location" type="System.Drawing.Point, System.Drawing">
-    <value>50, 26</value>
+    <value>66, 34</value>
+  </data>
+  <data name="UDCount.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="UDCount.Size" type="System.Drawing.Size, System.Drawing">
-    <value>61, 20</value>
+    <value>81, 22</value>
   </data>
   <data name="UDCount.TabIndex" type="System.Int32, mscorlib">
     <value>3</value>
@@ -217,13 +262,13 @@
     <value>UDCount</value>
   </data>
   <data name="&gt;&gt;UDCount.Type" xml:space="preserve">
-    <value>System.Windows.Forms.NumericUpDown, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.NumericUpDown, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;UDCount.Parent" xml:space="preserve">
     <value>tableLayoutPanel2</value>
   </data>
   <data name="&gt;&gt;UDCount.ZOrder" xml:space="preserve">
-    <value>2</value>
+    <value>3</value>
   </data>
   <data name="label1.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Left</value>
@@ -235,10 +280,13 @@
     <value>NoControl</value>
   </data>
   <data name="label1.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 29</value>
+    <value>4, 36</value>
+  </data>
+  <data name="label1.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 0, 4, 0</value>
   </data>
   <data name="label1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>41, 13</value>
+    <value>54, 17</value>
   </data>
   <data name="label1.TabIndex" type="System.Int32, mscorlib">
     <value>4</value>
@@ -250,13 +298,13 @@
     <value>label1</value>
   </data>
   <data name="&gt;&gt;label1.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;label1.Parent" xml:space="preserve">
     <value>tableLayoutPanel2</value>
   </data>
   <data name="&gt;&gt;label1.ZOrder" xml:space="preserve">
-    <value>3</value>
+    <value>4</value>
   </data>
   <data name="CBBetween.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Left</value>
@@ -268,10 +316,13 @@
     <value>NoControl</value>
   </data>
   <data name="CBBetween.Location" type="System.Drawing.Point, System.Drawing">
-    <value>117, 27</value>
+    <value>167, 34</value>
+  </data>
+  <data name="CBBetween.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="CBBetween.Size" type="System.Drawing.Size, System.Drawing">
-    <value>174, 17</value>
+    <value>227, 21</value>
   </data>
   <data name="CBBetween.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
@@ -283,25 +334,28 @@
     <value>CBBetween</value>
   </data>
   <data name="&gt;&gt;CBBetween.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;CBBetween.Parent" xml:space="preserve">
     <value>tableLayoutPanel2</value>
   </data>
   <data name="&gt;&gt;CBBetween.ZOrder" xml:space="preserve">
-    <value>4</value>
+    <value>5</value>
   </data>
   <data name="tableLayoutPanel2.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
     <value>Fill</value>
   </data>
   <data name="tableLayoutPanel2.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 16</value>
+    <value>4, 19</value>
+  </data>
+  <data name="tableLayoutPanel2.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="tableLayoutPanel2.RowCount" type="System.Int32, mscorlib">
-    <value>3</value>
+    <value>4</value>
   </data>
   <data name="tableLayoutPanel2.Size" type="System.Drawing.Size, System.Drawing">
-    <value>355, 72</value>
+    <value>473, 119</value>
   </data>
   <data name="tableLayoutPanel2.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -310,7 +364,7 @@
     <value>tableLayoutPanel2</value>
   </data>
   <data name="&gt;&gt;tableLayoutPanel2.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TableLayoutPanel, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.TableLayoutPanel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;tableLayoutPanel2.Parent" xml:space="preserve">
     <value>groupBox1</value>
@@ -319,16 +373,22 @@
     <value>0</value>
   </data>
   <data name="tableLayoutPanel2.LayoutSettings" type="System.Windows.Forms.TableLayoutSettings, System.Windows.Forms">
-    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="CBHeader" Row="0" RowSpan="1" Column="0" ColumnSpan="2" /&gt;&lt;Control Name="CBFooter" Row="2" RowSpan="1" Column="0" ColumnSpan="2" /&gt;&lt;Control Name="UDCount" Row="1" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="label1" Row="1" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="CBBetween" Row="1" RowSpan="1" Column="2" ColumnSpan="1" /&gt;&lt;/Controls&gt;&lt;Columns Styles="AutoSize,50,AutoSize,50,Absolute,436" /&gt;&lt;Rows Styles="AutoSize,0,Absolute,26,AutoSize,0" /&gt;&lt;/TableLayoutSettings&gt;</value>
+    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="CBLFLineEndings" Row="3" RowSpan="1" Column="0" ColumnSpan="2" /&gt;&lt;Control Name="CBHeader" Row="0" RowSpan="1" Column="0" ColumnSpan="2" /&gt;&lt;Control Name="CBFooter" Row="2" RowSpan="1" Column="0" ColumnSpan="2" /&gt;&lt;Control Name="UDCount" Row="1" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="label1" Row="1" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="CBBetween" Row="1" RowSpan="1" Column="2" ColumnSpan="1" /&gt;&lt;/Controls&gt;&lt;Columns Styles="AutoSize,50,AutoSize,50,Absolute,581" /&gt;&lt;Rows Styles="AutoSize,0,Absolute,32,AutoSize,0,AutoSize,0" /&gt;&lt;/TableLayoutSettings&gt;</value>
   </data>
   <data name="groupBox1.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
     <value>Fill</value>
   </data>
   <data name="groupBox1.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 3</value>
+    <value>4, 4</value>
+  </data>
+  <data name="groupBox1.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
+  </data>
+  <data name="groupBox1.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="groupBox1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>361, 91</value>
+    <value>481, 142</value>
   </data>
   <data name="groupBox1.TabIndex" type="System.Int32, mscorlib">
     <value>17</value>
@@ -340,7 +400,7 @@
     <value>groupBox1</value>
   </data>
   <data name="&gt;&gt;groupBox1.Type" xml:space="preserve">
-    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;groupBox1.Parent" xml:space="preserve">
     <value>tableLayoutPanel1</value>
@@ -355,13 +415,13 @@
     <value>NoControl</value>
   </data>
   <data name="label2.Location" type="System.Drawing.Point, System.Drawing">
-    <value>5, 102</value>
+    <value>7, 156</value>
   </data>
   <data name="label2.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>5, 5, 5, 5</value>
+    <value>7, 6, 7, 6</value>
   </data>
   <data name="label2.Size" type="System.Drawing.Size, System.Drawing">
-    <value>352, 91</value>
+    <value>475, 102</value>
   </data>
   <data name="label2.TabIndex" type="System.Int32, mscorlib">
     <value>5</value>
@@ -375,7 +435,7 @@ NOTE: If you export gcode to re-load inside LaserGRBL it is better to use quick 
     <value>label2</value>
   </data>
   <data name="&gt;&gt;label2.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;label2.Parent" xml:space="preserve">
     <value>tableLayoutPanel1</value>
@@ -429,10 +489,13 @@ NOTE: If you export gcode to re-load inside LaserGRBL it is better to use quick 
     <value>NoControl</value>
   </data>
   <data name="BtnSave.Location" type="System.Drawing.Point, System.Drawing">
-    <value>251, 3</value>
+    <value>334, 4</value>
+  </data>
+  <data name="BtnSave.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="BtnSave.Size" type="System.Drawing.Size, System.Drawing">
-    <value>107, 42</value>
+    <value>143, 52</value>
   </data>
   <data name="BtnSave.TabIndex" type="System.Int32, mscorlib">
     <value>15</value>
@@ -447,7 +510,7 @@ NOTE: If you export gcode to re-load inside LaserGRBL it is better to use quick 
     <value>BtnSave</value>
   </data>
   <data name="&gt;&gt;BtnSave.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;BtnSave.Parent" xml:space="preserve">
     <value>tableLayoutPanel3</value>
@@ -459,13 +522,16 @@ NOTE: If you export gcode to re-load inside LaserGRBL it is better to use quick 
     <value>Fill</value>
   </data>
   <data name="tableLayoutPanel3.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 218</value>
+    <value>4, 289</value>
+  </data>
+  <data name="tableLayoutPanel3.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="tableLayoutPanel3.RowCount" type="System.Int32, mscorlib">
     <value>1</value>
   </data>
   <data name="tableLayoutPanel3.Size" type="System.Drawing.Size, System.Drawing">
-    <value>361, 48</value>
+    <value>481, 60</value>
   </data>
   <data name="tableLayoutPanel3.TabIndex" type="System.Int32, mscorlib">
     <value>6</value>
@@ -474,7 +540,7 @@ NOTE: If you export gcode to re-load inside LaserGRBL it is better to use quick 
     <value>tableLayoutPanel3</value>
   </data>
   <data name="&gt;&gt;tableLayoutPanel3.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TableLayoutPanel, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.TableLayoutPanel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;tableLayoutPanel3.Parent" xml:space="preserve">
     <value>tableLayoutPanel1</value>
@@ -491,11 +557,14 @@ NOTE: If you export gcode to re-load inside LaserGRBL it is better to use quick 
   <data name="tableLayoutPanel1.Location" type="System.Drawing.Point, System.Drawing">
     <value>0, 0</value>
   </data>
+  <data name="tableLayoutPanel1.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
+  </data>
   <data name="tableLayoutPanel1.RowCount" type="System.Int32, mscorlib">
     <value>3</value>
   </data>
   <data name="tableLayoutPanel1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>367, 269</value>
+    <value>489, 353</value>
   </data>
   <data name="tableLayoutPanel1.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -504,7 +573,7 @@ NOTE: If you export gcode to re-load inside LaserGRBL it is better to use quick 
     <value>tableLayoutPanel1</value>
   </data>
   <data name="&gt;&gt;tableLayoutPanel1.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TableLayoutPanel, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.TableLayoutPanel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;tableLayoutPanel1.Parent" xml:space="preserve">
     <value>$this</value>
@@ -515,14 +584,17 @@ NOTE: If you export gcode to re-load inside LaserGRBL it is better to use quick 
   <data name="tableLayoutPanel1.LayoutSettings" type="System.Windows.Forms.TableLayoutSettings, System.Windows.Forms">
     <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="groupBox1" Row="0" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="label2" Row="1" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="tableLayoutPanel3" Row="2" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;/Controls&gt;&lt;Columns Styles="Percent,100" /&gt;&lt;Rows Styles="AutoSize,0,Percent,100,AutoSize,0" /&gt;&lt;/TableLayoutSettings&gt;</value>
   </data>
-  <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+  <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
   <data name="$this.AutoScaleDimensions" type="System.Drawing.SizeF, System.Drawing">
-    <value>6, 13</value>
+    <value>8, 16</value>
   </data>
   <data name="$this.ClientSize" type="System.Drawing.Size, System.Drawing">
-    <value>367, 269</value>
+    <value>489, 353</value>
+  </data>
+  <data name="$this.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="$this.StartPosition" type="System.Windows.Forms.FormStartPosition, System.Windows.Forms">
     <value>CenterParent</value>
@@ -534,6 +606,6 @@ NOTE: If you export gcode to re-load inside LaserGRBL it is better to use quick 
     <value>SaveOptionForm</value>
   </data>
   <data name="&gt;&gt;$this.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Form, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Form, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
 </root>


### PR DESCRIPTION
This resolves issue https://github.com/arkypita/LaserGRBL/issues/2036

The original problem is that some laser firmwares allow LF line endings ("\n") but not CRLF ("\r\n"). The line endings work correctly in the paid software, LightBurn.

This PR adds a checkbox in the advanced options to use LF line endings on the exported gcode file. The checkbox is unchecked by default since most users probably don't need this.

![SaveGcode](https://user-images.githubusercontent.com/8048702/225187941-3bbd16a5-9083-4120-8130-4f9fc62939fd.jpg)


