### PR TITLE
Loki of mute

### DIFF
--- a/LaserGRBL/Core/GrblCore.cs
+++ b/LaserGRBL/Core/GrblCore.cs
@@ -19,4354 +19,4353 @@ using static LaserGRBL.GrblCore;
 
 namespace LaserGRBL
 {
-	public enum Firmware
-	{ Grbl, Smoothie, Marlin, VigoWork }
-
-	/// <summary>
-	/// Description of CommandThread.
-	/// </summary>
-	public class GrblCore
-	{
-		//public static PSHelper.PSFile MaterialDB = PSHelper.PSFile.Load();
-		public static PSHelper.MaterialDB MaterialDB = PSHelper.MaterialDB.Load();
-
-		public static string GCODE_STD_HEADER = "G90 (use absolute coordinates)";
-		public static string GCODE_STD_PASSES = ";(Uncomment if you want to sink Z axis)\r\n;G91 (use relative coordinates)\r\n;G0 Z-1 (sinks the Z axis, 1mm)\r\n;G90 (use absolute coordinates)";
-		public static string GCODE_STD_FOOTER = "G0 X0 Y0 Z0 (move back to origin)";
-
-		[Serializable]
-		public class ThreadingMode
-		{
-			public readonly int StatusQuery;
-			public readonly int TxLong;
-			public readonly int TxShort;
-			public readonly int RxLong;
-			public readonly int RxShort;
-			private readonly string Name;
-
-			public ThreadingMode(int query, int txlong, int txshort, int rxlong, int rxshort, string name)
-			{ StatusQuery = query; TxLong = txlong; TxShort = txshort; RxLong = rxlong; RxShort = rxshort; Name = name; }
-
-			public static ThreadingMode Slow
-			{ get { return new ThreadingMode(2000, 15, 4, 2, 1, "Slow"); } }
-
-			public static ThreadingMode Quiet
-			{ get { return new ThreadingMode(1000, 10, 2, 1, 1, "Quiet"); } }
-
-			public static ThreadingMode Fast
-			{ get { return new ThreadingMode(500, 5, 1, 1, 0, "Fast"); } }
-
-			public static ThreadingMode UltraFast
-			{ get { return new ThreadingMode(250, 1, 0, 0, 0, "UltraFast"); } }
-
-			public static ThreadingMode Insane
-			{ get { return new ThreadingMode(200, 1, 0, 0, 0, "Insane"); } }
-
-			public override string ToString()
-			{ return Name; }
-
-			public override bool Equals(object obj)
-			{ return obj != null && obj is ThreadingMode && ((ThreadingMode)obj).Name == Name; }
-
-			public override int GetHashCode()
-			{
-				return base.GetHashCode();
-			}
-		}
-
-		public enum DetectedIssue
-		{
-			Unknown = 0,
-			ManualReset = -1,
-			ManualDisconnect = -2,
-			ManualAbort = -3,
-			StopResponding = 1,
-			//StopMoving = 2, 
-			UnexpectedReset = 3,
-			UnexpectedDisconnect = 4,
-			MachineAlarm = 5,
-		}
-
-		public enum MacStatus
-		{ Disconnected, Connecting, Idle, Run, Hold, Door, Home, Alarm, Check, Jog, Queue, Cooling, AutoHold, Tool } // "Tool" added in GrblHal
-
-		public enum JogDirection
-		{ None, Abort, Home, N, S, W, E, NW, NE, SW, SE, Zup, Zdown }
-
-		public enum StreamingMode
-		{ Buffered, Synchronous, RepeatOnError }
-
-		[Serializable]
-		public class GrblVersionInfo : IComparable, ICloneable
-		{
-			int mMajor;
-			int mMinor;
-			char mBuild;
-			bool mOrtur;
-			bool mGrblHal;
-
-			string mVendorInfo;
-			string mVendorVersion;
-
-			public GrblVersionInfo(int major, int minor, char build, string VendorInfo, string VendorVersion, bool IsHAL)
-			{
-				mMajor = major; mMinor = minor; mBuild = build;
-				mVendorInfo = VendorInfo;
-				mVendorVersion = VendorVersion;
-				mOrtur = VendorInfo != null && (VendorInfo.Contains("Ortur") || VendorInfo.Contains("Aufero"));
-				mGrblHal = IsHAL;
-			}
-
-			public GrblVersionInfo(int major, int minor, char build)
-			{ mMajor = major; mMinor = minor; mBuild = build; }
-
-			public GrblVersionInfo(int major, int minor)
-			{ mMajor = major; mMinor = minor; mBuild = (char)0; }
-
-			public static bool operator !=(GrblVersionInfo a, GrblVersionInfo b)
-			{ return !(a == b); }
-
-			public static bool operator ==(GrblVersionInfo a, GrblVersionInfo b)
-			{
-				if (Object.ReferenceEquals(a, null))
-					return Object.ReferenceEquals(b, null);
-				else
-					return a.Equals(b);
-			}
-
-			public static bool operator <(GrblVersionInfo a, GrblVersionInfo b)
-			{
-				if ((Object)a == null)
-					throw new ArgumentNullException("a");
-				return (a.CompareTo(b) < 0);
-			}
-
-			public static bool operator <=(GrblVersionInfo a, GrblVersionInfo b)
-			{
-				if ((Object)a == null)
-					throw new ArgumentNullException("a");
-				return (a.CompareTo(b) <= 0);
-			}
-
-			public static bool operator >(GrblVersionInfo a, GrblVersionInfo b)
-			{ return (b < a); }
-
-			public static bool operator >=(GrblVersionInfo a, GrblVersionInfo b)
-			{ return (b <= a); }
-
-			public override string ToString()
-			{
-				if (mBuild == (char)0)
-					return string.Format("{0}.{1}", mMajor, mMinor);
-				else
-					return string.Format("{0}.{1}{2}", mMajor, mMinor, mBuild);
-			}
-
-			public override bool Equals(object obj)
-			{
-				GrblVersionInfo v = obj as GrblVersionInfo;
-				return v != null && this.mMajor == v.mMajor && this.mMinor == v.mMinor && this.mBuild == v.mBuild && this.mOrtur == v.mOrtur && this.mGrblHal == v.mGrblHal;
-			}
-
-			public override int GetHashCode()
-			{
-				unchecked
-				{
-					int hash = 17;
-					// Maybe nullity checks, if these are objects not primitives!
-					hash = hash * 23 + mMajor.GetHashCode();
-					hash = hash * 23 + mMinor.GetHashCode();
-					hash = hash * 23 + mBuild.GetHashCode();
-					hash = hash * 23 + mOrtur.GetHashCode();
-					hash = hash * 23 + mGrblHal.GetHashCode();
-					return hash;
-				}
-			}
-
-			public int CompareTo(Object version)
-			{
-				if (version == null)
-					return 1;
-
-				GrblVersionInfo v = version as GrblVersionInfo;
-				if (v == null)
-					throw new ArgumentException("Argument must be GrblVersionInfo");
-
-				if (this.mMajor != v.mMajor)
-					if (this.mMajor > v.mMajor)
-						return 1;
-					else
-						return -1;
-
-				if (this.mMinor != v.mMinor)
-					if (this.mMinor > v.mMinor)
-						return 1;
-					else
-						return -1;
-
-				if (this.mBuild != v.mBuild)
-					if (this.mBuild > v.mBuild)
-						return 1;
-					else
-						return -1;
-
-				return 0;
-			}
-
-			public object Clone()
-			{ return this.MemberwiseClone(); }
-
-			public int Major => mMajor;
-			public int Minor => mMinor;
-			public bool IsOrtur => mOrtur;
-			public bool IsHAL => mGrblHal;
-			public bool IsLuckyOrturWiFi => IsOrtur && mVendorInfo == "Ortur Laser Master 3";
-			public string MachineName => mVendorInfo;
-
-			public string VendorName
-			{
-				get
-				{
-					if (mVendorInfo != null && mVendorInfo.ToLower().Contains("ortur"))
-						return "Ortur";
-					else if (mVendorInfo != null && mVendorInfo.ToLower().Contains("Vigotec"))
-						return "Vigotec";
-					else if (mBuild == '#')
-						return "Emulator";
-					else
-						return "Unknown";
-				}
-			}
-
-			public int OrturFWVersionNumber
-			{
-				get
-				{
-					try { return int.Parse(mVendorVersion); }
-					catch { return -1; }
-				}
-			}
-		}
-
-		public delegate void dlgIssueDetector(DetectedIssue issue);
-		public delegate void dlgOnMachineStatus();
-		public delegate void dlgOnOverrideChange();
-		public delegate void dlgOnLoopCountChange(decimal current);
-		public delegate void dlgJogStateChange(bool jog);
-
-		public event dlgIssueDetector IssueDetected;
-		public event dlgOnMachineStatus MachineStatusChanged;
-		public event GrblFile.OnFileLoadedDlg OnFileLoading;
-		public event GrblFile.OnFileLoadedDlg OnFileLoaded;
-		public event dlgOnOverrideChange OnOverrideChange;
-		public event dlgOnLoopCountChange OnLoopCountChange;
-		public event dlgJogStateChange JogStateChange;
-
-		private System.Windows.Forms.Control syncro;
-		protected ComWrapper.IComWrapper com;
-		private GrblFile file;
-		private System.Collections.Generic.Queue<GrblCommand> mQueue; //vera coda di quelli da mandare
-		private GrblCommand mRetryQueue; //coda[1] di quelli in attesa di risposta
-		private System.Collections.Generic.Queue<GrblCommand> mPending; //coda di quelli in attesa di risposta
-		private System.Collections.Generic.List<IGrblRow> mSent; //lista di quelli mandati
-
-		private System.Collections.Generic.Queue<GrblCommand> mQueuePtr; //puntatore a coda di quelli da mandare (normalmente punta a mQueue, salvo per import/export configurazione)
-		private System.Collections.Generic.List<IGrblRow> mSentPtr; //puntatore a lista di quelli mandati (normalmente punta a mSent, salvo per import/export configurazione)
-
-		private string mWelcomeSeen = null;
-		private string mVersionSeen = null;
-		protected int mUsedBuffer;
-
-		private const int DEFAULT_BUFFER_SIZE = 127;
-		private int mAutoBufferSize = DEFAULT_BUFFER_SIZE;
-		private GPoint mMPos;
-		private GPoint mWCO;
-		private int mGrblBlocks = -1;
-		private int mGrblBuffer = -1;
-		private int mFailedConnection = 0;
-		private JogDirection mPrenotedJogDirection = JogDirection.None;
-		private float mPrenotedJogSpeed = 100;
-		protected TimeProjection mTP = new TimeProjection();
-
-		private MacStatus mMachineStatus = MacStatus.Disconnected;
-
-
-		private float mCurF;
-		private float mCurS;
-
-		private int mCurOvLinear;
-		private int mCurOvRapids;
-		private int mCurOvPower;
-
-		private int mTarOvLinear;
-		private int mTarOvRapids;
-		private int mTarOvPower;
-
-		private decimal mLoopCount = 1;
-
-		protected Tools.PeriodicEventTimer QueryTimer;
-
-		private Tools.ThreadObject TX;
-		private Tools.ThreadObject RX;
-
-		private long connectStart;
-
-		protected ElapsedFromEvent debugLastStatusDelay;
-		protected ElapsedFromEvent debugLastMoveOrActivityDelay;
-
-		private ThreadingMode mThreadingMode = ThreadingMode.Fast;
-		private HotKeysManager mHotKeyManager;
-
-		public UsageStats.UsageCounters UsageCounters;
-
-		private string mDetectedIP = null;
-		private bool mDoingSend = false;
-
-
-
-		public GrblCore(System.Windows.Forms.Control syncroObject, PreviewForm cbform, JogForm jogform)
-		{
-			if (Type != Firmware.Grbl) Logger.LogMessage("Program", "Load {0} core", Type);
-
-			SetStatus(MacStatus.Disconnected);
-			syncro = syncroObject;
-			com = new ComWrapper.UsbSerial();
-
-			debugLastStatusDelay = new ElapsedFromEvent();
-			debugLastMoveOrActivityDelay = new ElapsedFromEvent();
-
-			//with version 4.5.0 default ThreadingMode change from "UltraFast" to "Fast"
-			if (!Settings.IsNewFile && Settings.PrevVersion < new Version(4, 5, 0))
-			{
-				ThreadingMode CurrentMode = Settings.GetObject("Threading Mode", ThreadingMode.Fast);
-				if (Equals(CurrentMode, ThreadingMode.Insane) || Equals(CurrentMode, ThreadingMode.UltraFast))
-					Settings.SetObject("Threading Mode", ThreadingMode.Fast);
-			}
-
-			mThreadingMode = Settings.GetObject("Threading Mode", ThreadingMode.Fast);
-
-
-
-			QueryTimer = new Tools.PeriodicEventTimer(TimeSpan.FromMilliseconds(mThreadingMode.StatusQuery), false);
-			TX = new Tools.ThreadObject(ThreadTX, 1, true, "Serial TX Thread", StartTX);
-			RX = new Tools.ThreadObject(ThreadRX, 1, true, "Serial RX Thread", null);
-
-			file = new GrblFile(0, 0, Configuration.TableWidth, Configuration.TableHeight);  //create a fake range to use with manual movements
-
-			file.OnFileLoading += RiseOnFileLoading;
-			file.OnFileLoaded += RiseOnFileLoaded;
-
-			mQueue = new System.Collections.Generic.Queue<GrblCommand>();
-			mPending = new System.Collections.Generic.Queue<GrblCommand>();
-			mSent = new System.Collections.Generic.List<IGrblRow>();
-			mUsedBuffer = 0;
-
-			mSentPtr = mSent;
-			mQueuePtr = mQueue;
-
-			mCurOvLinear = mCurOvRapids = mCurOvPower = 100;
-			mTarOvLinear = mTarOvRapids = mTarOvPower = 100;
-
-			if (!Settings.ExistObject("Hotkey Setup")) Settings.SetObject("Hotkey Setup", new HotKeysManager());
-			mHotKeyManager = Settings.GetObject<HotKeysManager>("Hotkey Setup", null);
-			mHotKeyManager.Init(this, cbform, jogform);
-
-			UsageCounters = new UsageStats.UsageCounters();
-
-			if (GrblVersion != null)
-				CSVD.LoadAppropriateCSV(GrblVersion); //load setting for last known version
-		}
-
-		internal void HotKeyOverride(HotKeysManager.HotKey.Actions action)
-		{
-
-			switch (action)
-			{
-				case HotKeysManager.HotKey.Actions.OverridePowerDefault:
-					mTarOvPower = 100; break;
-				case HotKeysManager.HotKey.Actions.OverridePowerUp:
-					mTarOvPower = Math.Min(mTarOvPower + 1, 200); break;
-				case HotKeysManager.HotKey.Actions.OverridePowerDown:
-					mTarOvPower = Math.Max(mTarOvPower - 1, 10); break;
-				case HotKeysManager.HotKey.Actions.OverrideLinearDefault:
-					mTarOvLinear = 100; break;
-				case HotKeysManager.HotKey.Actions.OverrideLinearUp:
-					mTarOvLinear = Math.Min(mTarOvLinear + 1, 200); break;
-				case HotKeysManager.HotKey.Actions.OverrideLinearDown:
-					mTarOvLinear = Math.Max(mTarOvLinear - 1, 10); break;
-				case HotKeysManager.HotKey.Actions.OverrideRapidDefault:
-					mTarOvRapids = 100; break;
-				case HotKeysManager.HotKey.Actions.OverrideRapidUp:
-					mTarOvRapids = Math.Min(mTarOvRapids * 2, 100); break;
-				case HotKeysManager.HotKey.Actions.OverrideRapidDown:
-					mTarOvRapids = Math.Max(mTarOvRapids / 2, 25); break;
-				default:
-					break;
-			}
-		}
-
-		internal string ValidateConfig(int parid, object value)
-		{
-			if (Configuration == null)
-				return null;
-
-			return Configuration.ValidateConfig(parid, value);
-		}
-
-		public virtual Firmware Type
-		{ get { return Firmware.Grbl; } }
-
-		public static GrblConfST Configuration
-		{
-			get
-			{
-				if (Settings.ExistObject("Grbl Configuration"))
-				{
-					Settings.SetObject("Grbl Configuration ST", new GrblConfST(Settings.GetObject("Grbl Configuration", (GrblConf)null)));  //convert old format with only numbers
-					Settings.DeleteObject("Grbl Configuration");                                                                            //delete old format
-				}
-				return Settings.GetObject("Grbl Configuration ST", new GrblConfST());
-			}
-			set
-			{
-				if (value.Count > 0 && value.GrblVersion != null)
-					Settings.SetObject("Grbl Configuration ST", value);
-			}
-		}
-
-		protected void SetStatus(MacStatus newStatus)
-		{
-			lock (this)
-			{
-				LaserLifeHandler.ComputeLaserTime(mMachineStatus);
-
-				if (mMachineStatus != newStatus)
-				{
-					MacStatus oldStatus = mMachineStatus;
-					mMachineStatus = newStatus;
-
-					Logger.LogMessage("SetStatus", "Machine status [{0}]", mMachineStatus);
-					if (oldStatus == MacStatus.Connecting && newStatus == MacStatus.Disconnected)
-						mFailedConnection++;
-					if (oldStatus == MacStatus.Connecting && newStatus != MacStatus.Disconnected)
-						mFailedConnection = 0;
-					if (oldStatus == MacStatus.Connecting && newStatus != MacStatus.Disconnected)
-						RefreshConfigOnConnect();
-					if (oldStatus == MacStatus.Connecting && newStatus != MacStatus.Disconnected)
-						SoundEvent.PlaySound(SoundEvent.EventId.Connect);
-					if (newStatus == MacStatus.Disconnected)
-						SoundEvent.PlaySound(SoundEvent.EventId.Disconnect);
-					if (IsAnyHoldState(oldStatus) && !IsAnyHoldState(newStatus))
-						mHoldByCoolingRequest = mHoldByUserRequest = false; //se sto uscendo da uno stato di hold per qualsiasi motivo (tipo un reset o altro) mi tolgo l'userHold e il coolingHold
-
-					RiseMachineStatusChanged();
-
-					if (mTP != null && mTP.InProgram)
-					{
-						if (InPause)
-							mTP.JobPause();
-						else
-							mTP.JobResume();
-					}
-
-					if (newStatus == MacStatus.Disconnected)
-						SetFS(0, 0);
-				}
-			}
-		}
-
-		private static bool IsAnyHoldState(MacStatus status)
-		{
-			return status == MacStatus.Hold || status == MacStatus.Cooling || status == MacStatus.AutoHold;
-		}
-
-		private void RefreshConfigOnConnect()
-		{
-			try { System.Threading.ThreadPool.QueueUserWorkItem(new System.Threading.WaitCallback(RefreshConfigOnConnect)); }
-			catch { }
-		}
-
-		internal virtual void SendHomingCommand()
-		{
-			EnqueueCommand(new GrblCommand("$H"));
-		}
-
-		internal virtual void SendUnlockCommand()
-		{
-			EnqueueCommand(new GrblCommand("$X"));
-		}
-
-		public GrblVersionInfo GrblVersion //attenzione! può essere null
-		{
-			get { return Settings.GetObject<GrblVersionInfo>("Last GrblVersion known", null); }
-			set
-			{
-				if (GrblVersion != null)
-					Logger.LogMessage("VersionInfo", "Detected Grbl v{0}", value);
-
-				if (GrblVersion == null || !GrblVersion.Equals(value))
-				{
-					CSVD.LoadAppropriateCSV(value);
-					Settings.SetObject("Last GrblVersion known", value);
-				}
-			}
-		}
-
-		protected void SetIssue(DetectedIssue issue)
-		{
-			mTP.JobIssue(issue);
-			Logger.LogMessage("Issue detector", "{0} [{1},{2},{3}]", issue, FreeBuffer, GrblBuffer, GrblBlock);
-
-			if (issue > 0) //negative numbers indicate issue caused by the user, so must not be report to UI
-			{
-				RiseIssueDetected(issue);
-				Telegram.NotifyEvent(String.Format("<b>Job Issue</b>\n{0}", issue));
-				SoundEvent.PlaySound(SoundEvent.EventId.Fatal);
-			}
-		}
-
-		void RiseJogStateChange(bool jog)
-		{
-			if (JogStateChange != null)
-			{
-				if (syncro.InvokeRequired)
-					syncro.BeginInvoke(new dlgJogStateChange(RiseJogStateChange), jog);
-				else
-					JogStateChange(jog);
-			}
-		}
-
-		void RiseIssueDetected(DetectedIssue issue)
-		{
-			if (IssueDetected != null)
-			{
-				if (syncro.InvokeRequired)
-					syncro.BeginInvoke(new dlgIssueDetector(RiseIssueDetected), issue);
-				else
-					IssueDetected(issue);
-			}
-		}
-
-		void RiseMachineStatusChanged()
-		{
-			if (MachineStatusChanged != null)
-			{
-				if (syncro.InvokeRequired)
-					syncro.BeginInvoke(new dlgOnMachineStatus(RiseMachineStatusChanged));
-				else
-					MachineStatusChanged();
-			}
-		}
-
-		void RiseOverrideChanged()
-		{
-			if (OnOverrideChange != null)
-			{
-				if (syncro.InvokeRequired)
-					syncro.BeginInvoke(new dlgOnOverrideChange(RiseOverrideChanged));
-				else
-					OnOverrideChange();
-			}
-		}
-
-		void RiseOnFileLoading(long elapsed, string filename)
-		{
-			mTP.Reset(true);
-
-			if (OnFileLoaded != null)
-				OnFileLoading(elapsed, filename);
-		}
-
-		void RiseOnFileLoaded(long elapsed, string filename)
-		{
-			mTP.Reset(true);
-
-			if (OnFileLoaded != null)
-				OnFileLoaded(elapsed, filename);
-		}
-
-		public GrblFile LoadedFile
-		{ get { return file; } }
-
-		public void ReOpenFile(System.Windows.Forms.Form parent)
-		{
-			if (CanReOpenFile)
-				OpenFile(parent, Settings.GetObject<string>("Core.LastOpenFile", null));
-		}
-
-		public static readonly List<string> ImageExtensions = new List<string>(new string[] { ".jpg", ".jpeg", ".bmp", ".png", ".gif" });
-		public static readonly List<string> GCodeExtensions = new List<string>(new string[] { ".nc", ".cnc", ".tap", ".gcode", ".ngc" });
-		public static readonly List<string> ProjectFileExtensions = new List<string>(new string[] { ".lps" });
-		public void OpenFile(System.Windows.Forms.Form parent, string filename = null, bool append = false)
-		{
-			if (!CanLoadNewFile) return;
-
-			try
-			{
-				if (filename == null)
-				{
-					using (System.Windows.Forms.OpenFileDialog ofd = new System.Windows.Forms.OpenFileDialog())
-					{
-						//pre-select last file if exist
-						string lastFN = Settings.GetObject<string>("Core.LastOpenFile", null);
-						if (lastFN != null && System.IO.File.Exists(lastFN))
-							ofd.FileName = lastFN;
-
-						ofd.Filter = "Any supported file|*.nc;*.cnc;*.tap;*.gcode;*.ngc;*.bmp;*.png;*.jpg;*.jpeg;*.gif;*.svg;*.lps|GCODE Files|*.nc;*.cnc;*.tap;*.gcode;*.ngc|Raster Image|*.bmp;*.png;*.jpg;*.jpeg;*.gif|Vector Image (experimental)|*.svg|LaserGRBL Project|*.lps";
-						ofd.CheckFileExists = true;
-						ofd.Multiselect = false;
-						ofd.RestoreDirectory = true;
-
-						System.Windows.Forms.DialogResult dialogResult = System.Windows.Forms.DialogResult.Cancel;
-						try
-						{
-							dialogResult = ofd.ShowDialog(parent);
-						}
-						catch (System.Runtime.InteropServices.COMException)
-						{
-							ofd.AutoUpgradeEnabled = false;
-							dialogResult = ofd.ShowDialog(parent);
-						}
-
-						if (dialogResult == System.Windows.Forms.DialogResult.OK)
-							filename = ofd.FileName;
-					}
-				}
-
-				if (filename == null) return;
-
-				Logger.LogMessage("OpenFile", "Open {0}", filename);
-				Settings.SetObject("Core.LastOpenFile", filename);
-
-				if (ImageExtensions.Contains(System.IO.Path.GetExtension(filename).ToLowerInvariant())) //import raster image
-				{
-					try
-					{
-						RasterConverter.RasterToLaserForm.CreateAndShowDialog(this, filename, parent, append);
-						UsageCounters.RasterFile++;
-					}
-					catch (Exception ex)
-					{ Logger.LogException("RasterImport", ex); }
-				}
-				else if (System.IO.Path.GetExtension(filename).ToLowerInvariant() == ".svg")
-				{
-					SvgConverter.SvgModeForm.Mode mode = SvgConverter.SvgModeForm.Mode.Vector;// SvgConverter.SvgModeForm.CreateAndShow(filename);
-					if (mode == SvgConverter.SvgModeForm.Mode.Vector)
-					{
-						try
-						{
-							SvgConverter.SvgToGCodeForm.CreateAndShowDialog(this, filename, parent, append);
-							UsageCounters.SvgFile++;
-						}
-						catch (Exception ex)
-						{ Logger.LogException("SvgImport", ex); }
-					}
-					else if (mode == SvgConverter.SvgModeForm.Mode.Raster)
-					{
-						string bmpname = filename + ".png";
-						string fcontent = System.IO.File.ReadAllText(filename);
-						Svg.SvgDocument svg = Svg.SvgDocument.FromSvg<Svg.SvgDocument>(fcontent);
-						svg.Ppi = 600;
-
-						using (Bitmap bmp = svg.Draw())
-						{
-							bmp.SetResolution(600, 600);
-
-							//codec options not supported in C# png encoder https://efundies.com/c-sharp-save-png/
-							//quality always 100%
-
-							//ImageCodecInfo codecinfo = GetEncoder(ImageFormat.Png);
-							//EncoderParameters paramlist = new EncoderParameters(1);
-							//paramlist.Param[0] = new EncoderParameter(Encoder.Quality, 30L); 
-
-
-							if (System.IO.File.Exists(bmpname))
-								System.IO.File.Delete(bmpname);
-
-							bmp.Save(bmpname/*, codecinfo, paramlist*/);
-						}
-
-						try
-						{
-							RasterConverter.RasterToLaserForm.CreateAndShowDialog(this, bmpname, parent, append);
-							UsageCounters.RasterFile++;
-							if (System.IO.File.Exists(bmpname))
-								System.IO.File.Delete(bmpname);
-						}
-						catch (Exception ex)
-						{ Logger.LogException("SvgBmpImport", ex); }
-					}
-				}
-				else if (GCodeExtensions.Contains(System.IO.Path.GetExtension(filename).ToLowerInvariant()))  //load GCODE file
-				{
-					Cursor.Current = Cursors.WaitCursor;
-
-					try
-					{
-						file.LoadFile(filename, append);
-						UsageCounters.GCodeFile++;
-					}
-					catch (Exception ex)
-					{ Logger.LogException("GCodeImport", ex); }
-
-					Cursor.Current = Cursors.Default;
-				}
-				else if (ProjectFileExtensions.Contains(System.IO.Path.GetExtension(filename).ToLowerInvariant()))  //load LaserGRBL project
-				{
-					var project = Project.LoadProject(filename);
-
-					for (var i = 0; i < project.Count; i++)
-					{
-						var settings = project[i];
-
-						// Save image temporary
-						var imageFilepath = $"{System.IO.Path.GetTempPath()}\\{settings["ImageName"]}";
-						Project.SaveImage(settings["ImageBase64"].ToString(), imageFilepath);
-
-						// Restore settings
-						foreach (var setting in settings.Where(setting =>
-							setting.Key != "ImageName" && setting.Key != "ImageBase64"))
-							Settings.SetObject(setting.Key, setting.Value);
-
-						// Open file
-						Settings.SetObject("Core.LastOpenFile", imageFilepath);
-						if (i == 0)
-							ReOpenFile(parent);
-						else
-							OpenFile(parent, imageFilepath, true);
-
-						// Delete temporary image file
-						System.IO.File.Delete(imageFilepath);
-					}
-				}
-				else
-				{
-					System.Windows.Forms.MessageBox.Show(Strings.UnsupportedFiletype, "Error", System.Windows.Forms.MessageBoxButtons.OK, System.Windows.Forms.MessageBoxIcon.Error);
-				}
-			}
-			catch (Exception ex)
-			{
-				Logger.LogException("OpenFile", ex);
-			}
-		}
-
-		private ImageCodecInfo GetEncoder(ImageFormat format)
-		{
-			ImageCodecInfo[] codecs = ImageCodecInfo.GetImageDecoders();
-			foreach (ImageCodecInfo codec in codecs)
-			{
-				if (codec.FormatID == format.Guid)
-				{
-					return codec;
-				}
-			}
-			return null;
-		}
-
-		public void SaveProgram(Form parent, bool header, bool footer, bool between, int cycles, bool useLFLineEndings)
-		{
-			if (HasProgram)
-			{
-				string filename = null;
-				using (SaveFileDialog sfd = new SaveFileDialog())
-				{
-					string lastFN = Settings.GetObject<string>("Core.LastOpenFile", null);
-					if (lastFN != null)
-					{
-						string fn = System.IO.Path.GetFileNameWithoutExtension(lastFN);
-						string path = System.IO.Path.GetDirectoryName(lastFN);
-						sfd.FileName = System.IO.Path.Combine(path, fn + ".nc");
-					}
-
-					sfd.Filter = "GCODE Files|*.nc";
-					sfd.AddExtension = true;
-					sfd.RestoreDirectory = true;
-
-					DialogResult rv = DialogResult.Cancel;
-					try
-					{
-						rv = sfd.ShowDialog(parent);
-					}
-					catch (System.Runtime.InteropServices.COMException)
-					{
-						sfd.AutoUpgradeEnabled = false;
-						rv = sfd.ShowDialog(parent);
-					}
-
-					if (rv == DialogResult.OK)
-						filename = sfd.FileName;
-				}
-
-				if (filename != null)
-					file.SaveGCODE(filename, header, footer, between, cycles, useLFLineEndings, this);
-			}
-		}
-
-		public void SaveProject(Form parent)
-		{
-			if (HasProgram)
-			{
-				string filename = null;
-				using (SaveFileDialog sfd = new SaveFileDialog())
-				{
-					string lastFN = Settings.GetObject<string>("Core.LastOpenFile", null);
-					if (lastFN != null)
-					{
-						string fn = System.IO.Path.GetFileNameWithoutExtension(lastFN);
-						string path = System.IO.Path.GetDirectoryName(lastFN);
-						sfd.FileName = System.IO.Path.Combine(path, fn + ".lps");
-					}
-
-					sfd.Filter = "LaserGRBL Project|*.lps";
-					sfd.AddExtension = true;
-					sfd.RestoreDirectory = true;
-
-					DialogResult rv = DialogResult.Cancel;
-					try
-					{
-						rv = sfd.ShowDialog(parent);
-					}
-					catch (System.Runtime.InteropServices.COMException)
-					{
-						sfd.AutoUpgradeEnabled = false;
-						rv = sfd.ShowDialog(parent);
-					}
-
-					if (rv == DialogResult.OK)
-						filename = sfd.FileName;
-				}
-
-				if (filename != null)
-					Project.StoreSettings(filename);
-			}
-		}
-
-		private void RefreshConfigOnConnect(object state) //da usare per la chiamata asincrona
-		{
-			System.Threading.Thread.Sleep(500); //allow the machine to send all the startup messages before refreshing config and info
-
-			try
-			{
-				RefreshConfig(RefreshCause.OnConnect);
-			}
-			catch (Exception ex) { Logger.LogMessage("Refresh Config", ex.Message); }
-
-			try { RefreshMachineInfo(); }
-			catch (Exception ex) { Logger.LogMessage("Refresh Config", ex.Message); }
-		}
-
-		public virtual void RefreshMachineInfo()
-		{
-			if (Settings.GetObject("Query MachineInfo ($I) at connect", true))
-			{
-				try
-				{
-					//GrblConf conf = new GrblConf(GrblVersion);
-					GrblCommand cmd = new GrblCommand("$I");
-
-					lock (this)
-					{
-						mSentPtr = new List<IGrblRow>(); //assign sent queue
-						mQueuePtr = new Queue<GrblCommand>();
-						mQueuePtr.Enqueue(cmd);
-					}
-
-					Tools.PeriodicEventTimer WaitResponseTimeout = new Tools.PeriodicEventTimer(TimeSpan.FromSeconds(10), true);
-
-					//resta in attesa dell'invio del comando e della risposta
-					while (cmd.Status == GrblCommand.CommandStatus.Queued || cmd.Status == GrblCommand.CommandStatus.WaitingResponse)
-					{
-						if (WaitResponseTimeout.Expired)
-							throw new TimeoutException("No response received from grbl!");
-						else
-							System.Threading.Thread.Sleep(10);
-					}
-
-					if (cmd.Status == GrblCommand.CommandStatus.ResponseGood)
-					{
-						//attendi la ricezione di tutti i parametri
-						long tStart = Tools.HiResTimer.TotalMilliseconds;
-						long tLast = tStart;
-						int counter = mSentPtr.Count;
-						int target = 2 + 1; //il +1 è il comando $I
-
-						//finché ne devo ricevere ancora && l'ultima risposta è più recente di 500mS && non sono passati più di 5s totali
-						while (mSentPtr.Count < target && Tools.HiResTimer.TotalMilliseconds - tLast < 500 && Tools.HiResTimer.TotalMilliseconds - tStart < 5000)
-						{
-							if (mSentPtr.Count != counter)
-							{ tLast = Tools.HiResTimer.TotalMilliseconds; counter = mSentPtr.Count; }
-							else
-								System.Threading.Thread.Sleep(10);
-						}
-
-						foreach (IGrblRow row in mSentPtr) //read the reply
-						{
-							string rline = row.GetDecodedMessage();
-							if (IsIVerMessage(rline))
-								ManageVerMessage(rline);
-							else if (IsIOptMessage(rline))
-								ManageOptMessage(rline);
-						}
-					}
-				}
-				finally
-				{
-					lock (this)
-					{
-						mQueuePtr = mQueue;
-						mSentPtr = mSent; //restore queue
-					}
-				}
-			}
-		}
-
-		private void ManageOptMessage(string rline)
-		{
-			try
-			{
-				rline = rline.Substring(5, rline.Length - 6);
-				string[] arr = rline.Split(',');
-				string letters = arr.Length > 0 ? arr[0] : null;
-				int bbuffer = arr.Length > 1 ? int.Parse(arr[1]) : 0;
-				int txbuffer = arr.Length > 2 ? int.Parse(arr[2]) : 0;
-
-				if (txbuffer > DEFAULT_BUFFER_SIZE) //more then default buffer size
-					EnlargeBuffer(txbuffer, true);
-
-			}
-			catch (Exception ex)
-			{
-				Logger.LogMessage("OptionsMessage", "Ex on [{0}] message", rline);
-				Logger.LogException("OptionsMessage", ex);
-			}
-		}
-
-		private void ManageVerMessage(string rline)
-		{
-			try
-			{
-				rline = rline.Substring(5, rline.Length - 6);
-				//if (rline.ToLower().Contains("neje"))
-				//    GrblVersion?.IsNeje = true;
-			}
-			catch (Exception ex)
-			{
-				Logger.LogMessage("VersionMessage", "Ex on [{0}] message", rline);
-				Logger.LogException("VersionMessage", ex);
-			}
-		}
-
-		public enum RefreshCause { OnConnect, OnDialog, OnRead, OnExport, OnImport, OnWriteBegin, OnWriteEnd }
-		public virtual void RefreshConfig(RefreshCause cause)
-		{
-			if (CanReadWriteConfig)
-			{
-				try
-				{
-					Logger.LogMessage("Refresh Config", "Refreshing grbl configuration [{0}]", cause);
-
-					GrblConfST conf = new GrblConfST(GrblVersion);
-					GrblCommand cmd = new GrblCommand("$$");
-
-					lock (this)
-					{
-						mSentPtr = new List<IGrblRow>(); //assign sent queue
-						mQueuePtr = new Queue<GrblCommand>();
-						mQueuePtr.Enqueue(cmd);
-					}
-
-					PeriodicEventTimer WaitResponseTimeout = new PeriodicEventTimer(TimeSpan.FromSeconds(10), true);
-
-					//resta in attesa dell'invio del comando e della risposta
-					while (cmd.Status == GrblCommand.CommandStatus.Queued || cmd.Status == GrblCommand.CommandStatus.WaitingResponse)
-					{
-						if (WaitResponseTimeout.Expired)
-							throw new TimeoutException("No response received from grbl!");
-						else
-							System.Threading.Thread.Sleep(10);
-					}
-
-					if (cmd.Status == GrblCommand.CommandStatus.ResponseGood)
-					{
-						//attendi la ricezione di tutti i parametri
-						long tStart = Tools.HiResTimer.TotalMilliseconds;
-						long tLast = tStart;
-						int counter = mSentPtr.Count;
-						int target = conf.ExpectedCount + 1; //il +1 è il comando $$
-
-						//finché ne devo ricevere ancora && l'ultima risposta è più recente di 500mS && non sono passati più di 5s totali
-						while (mSentPtr.Count < target && HiResTimer.TotalMilliseconds - tLast < 500 && Tools.HiResTimer.TotalMilliseconds - tStart < 5000)
-						{
-							if (mSentPtr.Count != counter)
-							{ tLast = HiResTimer.TotalMilliseconds; counter = mSentPtr.Count; }
-							else
-								System.Threading.Thread.Sleep(10);
-						}
-
-						foreach (IGrblRow row in mSentPtr)
-						{
-							if (row is GrblMessage)
-								conf.AddOrUpdate(((GrblMessage)row).GetNativeMessage());
-						}
-
-						Configuration = conf; //accept configuration
-
-						if (conf.Count < conf.ExpectedCount) //log but do not show error if some param is missing
-							Logger.LogMessage("Refresh Config", "Wrong number of config param found! (Expected: {0} Found: {1})", conf.Count, conf.ExpectedCount);
-						else
-							Logger.LogMessage("Refresh Config", "Configuration successfully received! (Expected: {0} Found: {1})", conf.Count, conf.ExpectedCount);
-					}
-				}
-				catch (Exception ex)
-				{
-					Logger.LogException("Refresh Config", ex);
-					throw ex;
-				}
-				finally
-				{
-					lock (this)
-					{
-						mQueuePtr = mQueue;
-						mSentPtr = mSent; //restore queue
-					}
-				}
-			}
-			else
-			{
-				Logger.LogMessage("Refresh Config", "Cannot refresh config now [{0}] [Connected:{1} Program:{2} Status:{3}]", cause, IsConnected, InProgram, MachineStatus);
-			}
-		}
-
-
-
-		public class ReadConfigCountException : Exception
-		{
-			public ReadConfigCountException(string message) : base(message)
-			{
-			}
-		}
-
-		public class WriteConfigException : Exception
-		{
-			private System.Collections.Generic.List<IGrblRow> ErrorLines = new System.Collections.Generic.List<IGrblRow>();
-
-			public WriteConfigException(System.Collections.Generic.List<IGrblRow> mSentPtr)
-			{
-				foreach (IGrblRow row in mSentPtr)
-					if (row is GrblCommand)
-						if (((GrblCommand)row).Status != GrblCommand.CommandStatus.ResponseGood)
-							ErrorLines.Add(row);
-			}
-
-			public override string Message
-			{
-				get
-				{
-					string rv = "";
-					foreach (IGrblRow r in ErrorLines)
-						rv += string.Format("{0} {1}\n", r.GetDecodedMessage(), r.GetResult(true, false));
-					return rv.Trim();
-				}
-			}
-
-			public List<IGrblRow> Errors
-			{ get { return ErrorLines; } }
-		}
-
-		public string DetectedIP => mDetectedIP;
-
-		internal void WriteWiFiConfig(string ssid, string password)
-		{
-			//throw new NotImplementedException();
-			mDetectedIP = null;
-			if (CanReadWriteConfig)
-			{
-				lock (this)
-				{
-					//mSentPtr = new System.Collections.Generic.List<IGrblRow>(); //assign sent queue
-					//mQueuePtr = new System.Collections.Generic.Queue<GrblCommand>();
-
-					mQueuePtr.Enqueue(new GrblCommand(string.Format("${0}={1}", 74, ssid), 0, true));
-					mQueuePtr.Enqueue(new GrblCommand(string.Format("${0}={1}", 75, password), 0, true));
-					mQueuePtr.Enqueue(new GrblCommand("$WRS"));
-				}
-
-				try
-				{
-					while (com.IsOpen && (mQueuePtr.Count > 0 || HasPendingCommands())) //resta in attesa del completamento della comunicazione
-						;
-
-					int errors = 0;
-					foreach (IGrblRow row in mSentPtr)
-					{
-						if (row is GrblCommand)
-							if (((GrblCommand)row).Status != GrblCommand.CommandStatus.ResponseGood)
-								errors++;
-					}
-
-					//if (errors > 0)
-					//	throw new WriteConfigException(mSentPtr);
-				}
-				catch (Exception ex)
-				{
-					//Logger.LogException("Write Config", ex);
-					//throw (ex);
-				}
-				finally
-				{
-					//lock (this)
-					//{
-					//	//mQueuePtr = mQueue;
-					//	//mSentPtr = mSent; //restore queue
-					//}
-				}
-			}
-
-		}
-
-		public void WriteConfig(List<GrblConfST.GrblConfParam> config)
-		{
-			if (CanReadWriteConfig)
-			{
-				lock (this)
-				{
-					mSentPtr = new System.Collections.Generic.List<IGrblRow>(); //assign sent queue
-					mQueuePtr = new System.Collections.Generic.Queue<GrblCommand>();
-
-					foreach (GrblConfST.GrblConfParam p in config)
-						mQueuePtr.Enqueue(new GrblCommand(string.Format("${0}={1}", p.Number, p.Value), 0, true));
-				}
-
-				try
-				{
-					while (com.IsOpen && (mQueuePtr.Count > 0 || HasPendingCommands())) //resta in attesa del completamento della comunicazione
-						;
-
-					int errors = 0;
-					foreach (IGrblRow row in mSentPtr)
-					{
-						if (row is GrblCommand)
-							if (((GrblCommand)row).Status != GrblCommand.CommandStatus.ResponseGood)
-								errors++;
-					}
-
-					if (errors > 0)
-						throw new WriteConfigException(mSentPtr);
-				}
-				catch (Exception ex)
-				{
-					Logger.LogException("Write Config", ex);
-					throw (ex);
-				}
-				finally
-				{
-					lock (this)
-					{
-						mQueuePtr = mQueue;
-						mSentPtr = mSent; //restore queue
-					}
-				}
-			}
-		}
-
-
-		public void RunProgram(Form parent)
-		{
-			try
-			{
-				if (CanSendFile)
-				{
-					mDoingSend = true;
-
-					if (mTP.Executed == 0 || mTP.Executed == mTP.Target) //mai iniziato oppure correttamente finito
-						RunProgramFromStart(false, true);
-					else
-						UserWantToContinue(parent);
-				}
-			}
-			catch { }
-			finally { mDoingSend = false; }
-		}
-
-		public void AbortProgram()
-		{
-			if (CanAbortProgram)
-			{
-				try
-				{
-					Logger.LogMessage("ManualAbort", "Program aborted by user action!");
-
-					SetIssue(DetectedIssue.ManualAbort);
-					mTP.JobEnd(true);
-
-					lock (this)
-					{
-						mQueue.Clear(); //flush the queue of item to send
-						mQueue.Enqueue(new GrblCommand("M5")); //shut down laser
-					}
-				}
-				catch (Exception ex)
-				{
-					Logger.LogException("Abort Program", ex);
-				}
-
-			}
-		}
-
-		public void RunProgramFromPosition(Form parent)
-		{
-			if (CanSendFile)
-			{
-				bool homing = false;
-				int position = LaserGRBL.RunFromPositionForm.CreateAndShowDialog(parent, LoadedFile.Count, Configuration.HomingEnabled, out homing);
-
-				if (position >= 0)
-					ContinueProgramFromKnown(position, homing, false);
-			}
-		}
-
-		private void UserWantToContinue(Form parent)
-		{
-			bool setwco = mWCO == GPoint.Zero && mTP.LastKnownWCO != GPoint.Zero;
-			bool homing = MachinePosition == GPoint.Zero && mTP.LastIssue != DetectedIssue.ManualAbort && mTP.LastIssue != DetectedIssue.ManualReset; //potrebbe essere dovuto ad un hard reset -> posizione non affidabile
-			int position = ResumeJobForm.CreateAndShowDialog(parent, mTP.Executed, mTP.Sent, mTP.Target, mTP.LastIssue, Configuration.HomingEnabled, homing, out homing, setwco, setwco, out setwco, mTP.LastKnownWCO);
-
-			if (position == 0)
-				RunProgramFromStart(homing);
-			if (position > 0)
-				ContinueProgramFromKnown(position, homing, setwco);
-		}
-
-		private void RunProgramFromStart(bool homing, bool first = false, bool pass = false)
-		{
-			//solo se non siamo tra le passate
-			if (!pass && !SafetyCountdown.CanGo())
-				return;
-
-			lock (this)
-			{
-				ClearQueue(true);
-
-				mTP.Reset(first);
-
-				if (homing)
-				{
-					Logger.LogMessage("EnqueueProgram", "Push Homing ($H)");
-					mQueuePtr.Enqueue(new GrblCommand("$H"));
-				}
-
-				if (first)
-					OnJobBegin();
-
-				if (pass)
-					OnJobCycle();
-
-
-				Logger.LogMessage("EnqueueProgram", "Push File, {0} lines", file.Count);
-				foreach (GrblCommand cmd in file)
-					mQueuePtr.Enqueue(cmd.Clone() as GrblCommand);
-
-				mTP.JobStart(LoadedFile, mQueuePtr, first);
-				Logger.LogMessage("EnqueueProgram", "Running program, {0} lines", file.Count);
-			}
-		}
-
-		private void OnJobCycle()
-		{
-			Logger.LogMessage("EnqueueProgram", "Push Passes");
-			ExecuteCustombutton(Settings.GetObject("GCode.CustomPasses", GrblCore.GCODE_STD_PASSES));
-		}
-
-		protected virtual void OnJobBegin()
-		{
-			Logger.LogMessage("EnqueueProgram", "Push Header");
-			ExecuteCustombutton(Settings.GetObject("GCode.CustomHeader", GrblCore.GCODE_STD_HEADER));
-		}
-
-		protected virtual void OnJobEnd()
-		{
-			Logger.LogMessage("EnqueueProgram", "Push Footer");
-			ExecuteCustombutton(Settings.GetObject("GCode.CustomFooter", GrblCore.GCODE_STD_FOOTER));
-		}
-
-		private void ContinueProgramFromKnown(int position, bool homing, bool setwco)
-		{
-			if (!SafetyCountdown.CanGo())
-				return;
-
-			lock (this)
-			{
-
-				ClearQueue(false); //lascia l'eventuale lista delle cose già mandate, se ce l'hai ancora
-
-				mSentPtr.Add(new GrblMessage(string.Format("[resume from #{0}]", position + 1), false));
-				Logger.LogMessage("ResumeProgram", "Resume program from #{0}", position + 1);
-
-				GrblCommand.StatePositionBuilder spb = new GrblCommand.StatePositionBuilder();
-
-				if (homing) mQueuePtr.Enqueue(new GrblCommand("$H"));
-
-				if (setwco)
-				{
-					//compute current point and set offset
-					GPoint pos = homing ? GPoint.Zero : MachinePosition;
-					GPoint wco = mTP.LastKnownWCO;
-					GPoint cur = pos - wco;
-					mQueue.Enqueue(new GrblCommand(String.Format("G92 X{0} Y{1} Z{2}", cur.X.ToString(System.Globalization.CultureInfo.InvariantCulture), cur.Y.ToString(System.Globalization.CultureInfo.InvariantCulture), cur.Z.ToString(System.Globalization.CultureInfo.InvariantCulture))));
-				}
-
-				for (int i = 0; i < position && i < file.Count; i++) //analizza fino alla posizione
-					spb.AnalyzeCommand(file[i], false);
-
-				mQueuePtr.Enqueue(new GrblCommand("G90")); //absolute coordinate
-				mQueuePtr.Enqueue(new GrblCommand(string.Format("M5 G0 {0} {1} {2} {3} {4}", spb.X, spb.Y, spb.Z, spb.F, spb.S))); //fast go to the computed position with laser off and set speed and power
-				mQueuePtr.Enqueue(new GrblCommand(spb.GetSettledModals()));
-
-				mTP.JobContinue(LoadedFile, position, mQueuePtr.Count);
-
-				for (int i = position; i < file.Count; i++) //enqueue remaining commands
-				{
-					if (spb != null) //check the very first movement command and ensure modal MotionMode is settled
-					{
-						GrblCommand cmd = file[i].Clone() as GrblCommand;
-						cmd.BuildHelper();
-						if (cmd.IsMovement && cmd.G == null)
-							mQueuePtr.Enqueue(new GrblCommand(spb.MotionMode, cmd));
-						else
-							mQueuePtr.Enqueue(cmd);
-						cmd.DeleteHelper();
-						spb = null; //only the first time
-					}
-					else
-					{
-						mQueuePtr.Enqueue(file[i].Clone() as GrblCommand);
-					}
-				}
-			}
-		}
-
-		public bool HasProgram
-		{ get { return file != null && file.Count > 0; } }
-
-		public void EnqueueCommand(GrblCommand cmd)
-		{
-			lock (this)
-			{ mQueuePtr.Enqueue(cmd.Clone() as GrblCommand); }
-		}
-
-		public void Configure(ComWrapper.WrapperType wraptype, params object[] conf)
-		{
-			if (wraptype == ComWrapper.WrapperType.UsbSerial && (com == null || com.GetType() != typeof(ComWrapper.UsbSerial)))
-				com = new ComWrapper.UsbSerial();
-			else if (wraptype == ComWrapper.WrapperType.UsbSerial2 && (com == null || com.GetType() != typeof(ComWrapper.UsbSerial2)))
-				com = new ComWrapper.UsbSerial2();
-			else if (wraptype == ComWrapper.WrapperType.Telnet && (com == null || com.GetType() != typeof(ComWrapper.Telnet)))
-				com = new ComWrapper.Telnet();
-			else if (wraptype == ComWrapper.WrapperType.LaserWebESP8266 && (com == null || com.GetType() != typeof(ComWrapper.LaserWebESP8266)))
-				com = new ComWrapper.LaserWebESP8266();
-			else if (wraptype == ComWrapper.WrapperType.Emulator && (com == null || com.GetType() != typeof(ComWrapper.Emulator)))
-				com = new ComWrapper.Emulator();
-
-			com.Configure(conf);
-		}
-
-		public void OpenCom()
-		{
-			try
-			{
-				mAutoBufferSize = DEFAULT_BUFFER_SIZE; //reset to default buffer size
-				SetStatus(MacStatus.Connecting);
-				connectStart = Tools.HiResTimer.TotalMilliseconds;
-
-				if (!com.IsOpen)
-					com.Open();
-
-				lock (this)
-				{
-					RX.Start();
-					TX.Start();
-				}
-			}
-			catch (Exception ex)
-			{
-				Logger.LogMessage("OpenCom", "Error: {0}", ex.Message);
-				SetStatus(MacStatus.Disconnected);
-				com.Close(true);
-				System.Windows.Forms.MessageBox.Show(ex.Message, Strings.BoxConnectErrorTitle, System.Windows.Forms.MessageBoxButtons.OK, System.Windows.Forms.MessageBoxIcon.Error);
-			}
-		}
-
-		public void CloseCom(bool user)
-		{
-			if (mTP.LastIssue == DetectedIssue.Unknown && MachineStatus == MacStatus.Run && InProgram)
-				SetIssue(user ? DetectedIssue.ManualDisconnect : DetectedIssue.UnexpectedDisconnect);
-
-			try
-			{
-				if (com.IsOpen)
-					com.Close(!user);
-
-				mUsedBuffer = 0;
-				mTP.JobEnd(true);
-
-				TX.Stop();
-				RX.Stop();
-
-				lock (this)
-				{ ClearQueue(false); } //non resettare l'elenco delle cose mandate così da non sbiancare la lista
-
-				SetStatus(MacStatus.Disconnected);
-			}
-			catch (Exception ex)
-			{
-				Logger.LogException("CloseCom", ex);
-			}
-		}
-
-		internal void Exiting()
-		{
-			try { CloseCom(true); }
-			catch { }
-
-			try { RX.Stop(); }
-			catch { }
-
-			try { TX.Stop(); }
-			catch { }
-
-			LaserLifeHandler.SaveNow();
-		}
-
-		public bool IsConnected => mMachineStatus != MacStatus.Disconnected && mMachineStatus != MacStatus.Connecting;
-
-		#region Comandi immediati
-
-		public void CycleStartResume(bool auto)
-		{
-			if (CanResumeHold)
-			{
-				mHoldByCoolingRequest = mHoldByUserRequest = false;
-				SendImmediate(126);
-			}
-		}
-
-		public void FeedHold(bool cooling)
-		{
-			if (CanFeedHold)
-			{
-				mHoldByUserRequest = !cooling;
-				mHoldByCoolingRequest = cooling;
-				SendImmediate(33);
-			}
-		}
-
-		public void SafetyDoor()
-		{ SendImmediate(64); }
-
-		// GRBL & smoothie : Send "?" to retrieve position
-		// MarlinCore : Override : Send "M114\n"
-		protected virtual void QueryPosition()
-		{ SendImmediate(63, true); }
-
-		public void GrblReset() //da comando manuale esterno (pulsante)
-		{
-			if (CanResetGrbl)
-			{
-				if (mTP.LastIssue == DetectedIssue.Unknown && MachineStatus == MacStatus.Run && InProgram)
-					SetIssue(DetectedIssue.ManualReset);
-				InternalReset(true);
-			}
-		}
-
-		private void InternalReset(bool device)
-		{
-			lock (this)
-			{
-				ClearQueue(true);
-				mUsedBuffer = 0;
-				mTP.JobEnd(true);
-				mCurOvLinear = mCurOvRapids = mCurOvPower = 100;
-				mTarOvLinear = mTarOvRapids = mTarOvPower = 100;
-
-				if (device) SendBoardResetCommand();
-			}
-			RiseOverrideChanged();
-		}
-
-		protected virtual void SendBoardResetCommand()
-		{
-			SendImmediate(24);
-		}
-
-		public virtual void SendImmediate(byte b, bool mute = false)
-		{
-			try
-			{
-				if (!mute) Logger.LogMessage("SendImmediate", "Send Immediate Command [0x{0:X}]", b);
-
-				lock (this)
-				{ if (com.IsOpen) com.Write(b); }
-			}
-			catch (Exception ex)
-			{ Logger.LogException("SendImmediate", ex); }
-		}
-
-		#endregion
-
-		#region Public Property
-
-		public int ProgramTarget
-		{ get { return mTP.Target; } }
-
-		public int ProgramSent
-		{ get { return mTP.Sent; } }
-
-		public int ProgramExecuted
-		{ get { return mTP.Executed; } }
-
-		public TimeSpan ProgramTime
-		{ get { return mTP.TotalJobTime; } }
-
-		public TimeSpan ProgramGlobalTime
-		{ get { return mTP.TotalGlobalJobTime; } }
-
-		public TimeSpan ProjectedTime
-		{ get { return mTP.ProjectedTarget; } }
-
-		public MacStatus MachineStatus
-		{ get { return mMachineStatus; } }
-
-		public bool InProgram
-		{ get { return mTP.InProgram; } }
-
-		public GPoint MachinePosition
-		{ get { return mMPos; } }
-
-		public GPoint WorkPosition //WCO = MPos - WPos
-		{ get { return mMPos - mWCO; } }
-
-		public GPoint WorkingOffset
-		{ get { return mWCO; } }
-
-		public int Executed
-		{ get { return mSent.Count; } }
-
-		public List<IGrblRow> SentCommand(int index, int count)
-		{
-			index = Math.Min(index, mSent.Count - 1);       //force index to be in range
-			count = Math.Min(count, mSent.Count - index);   //force count to be in range
-
-			if (index >= 0 && count > 0)
-				return mSent.GetRange(index, count);
-			else
-				return new System.Collections.Generic.List<IGrblRow>();
-		}
-		#endregion
-
-		#region Grbl Version Support
-
-		public bool SupportRTO
-		{ get { return GrblVersion != null && GrblVersion >= new GrblVersionInfo(1, 1); } }
-
-		public virtual bool SupportTrueJogging
-		{ get { return GrblVersion != null && GrblVersion >= new GrblVersionInfo(1, 1); } }
-
-		public bool SupportCSV
-		{ get { return GrblVersion != null && GrblVersion >= new GrblVersionInfo(1, 1); } }
-
-		public bool SupportOverride
-		{ get { return GrblVersion != null && GrblVersion >= new GrblVersionInfo(1, 1); } }
-
-		public bool SupportLaserMode
-		{ get { return GrblVersion != null && GrblVersion >= new GrblVersionInfo(1, 1); } }
-
-		#endregion
-
-		public bool JogEnabled
-		{
-			get
-			{
-				if (SupportTrueJogging)
-					return IsConnected && (MachineStatus == GrblCore.MacStatus.Idle || MachineStatus == GrblCore.MacStatus.Jog);
-				else
-					return IsConnected && (MachineStatus == GrblCore.MacStatus.Idle || MachineStatus == GrblCore.MacStatus.Run) && !InProgram;
-			}
-		}
-
-		internal void EnqueueZJog(JogDirection dir, decimal step, bool fast)
-		{
-			if (JogEnabled)
-			{
-				mPrenotedJogSpeed = (fast ? 100000 : JogSpeed);
-
-				if (SupportTrueJogging)
-					DoJogV11(dir, step);
-				else
-					EmulateJogV09(dir, step); //immediato
-			}
-		}
-
-		public void BeginJog(PointF target, bool fast)
-		{
-			if (JogEnabled)
-			{
-				mPrenotedJogSpeed = (fast ? 100000 : JogSpeed);
-				target = LimitToBound(target);
-
-				if (SupportTrueJogging)
-					DoJogV11(target);
-				else
-					EmulateJogV09(target);
-			}
-		}
-
-		private PointF LimitToBound(PointF target)
-		{
-			if (Configuration.SoftLimit)
-			{
-				GPoint p = mWCO;
-				PointF rv = new PointF(Math.Min(Math.Max(target.X, -mWCO.X), (float)Configuration.TableWidth - mWCO.X), Math.Min(Math.Max(target.Y, -mWCO.Y), (float)Configuration.TableHeight - mWCO.Y));
-				return rv;
-			}
-
-			return target;
-		}
-
-		public void BeginJog(JogDirection dir, bool fast) //da chiamare su ButtonDown
-		{
-			if (JogEnabled)
-			{
-				mPrenotedJogSpeed = (fast ? 100000 : JogSpeed);
-
-				if (SupportTrueJogging)
-					DoJogV11(dir, JogStep);
-				else
-					EmulateJogV09(dir, JogStep);
-			}
-		}
-
-		private void EmulateJogV09(JogDirection dir, decimal step) //emulate jog using plane G-Code
-		{
-			if (dir == JogDirection.Home)
-			{
-				EnqueueCommand(new GrblCommand(string.Format("G90")));
-				EnqueueCommand(new GrblCommand(string.Format("G0X0Y0F{0}", mPrenotedJogSpeed)));
-			}
-			else
-			{
-				string cmd = "G0";
-
-				if (dir == JogDirection.NE || dir == JogDirection.E || dir == JogDirection.SE)
-					cmd += $"X{step.ToString("0.0", NumberFormatInfo.InvariantInfo)}";
-				if (dir == JogDirection.NW || dir == JogDirection.W || dir == JogDirection.SW)
-					cmd += $"X-{step.ToString("0.0", NumberFormatInfo.InvariantInfo)}";
-				if (dir == JogDirection.NW || dir == JogDirection.N || dir == JogDirection.NE)
-					cmd += $"Y{step.ToString("0.0", NumberFormatInfo.InvariantInfo)}";
-				if (dir == JogDirection.SW || dir == JogDirection.S || dir == JogDirection.SE)
-					cmd += $"Y-{step.ToString("0.0", NumberFormatInfo.InvariantInfo)}";
-				if (dir == JogDirection.Zdown)
-					cmd += $"Z-{step.ToString("0.0", NumberFormatInfo.InvariantInfo)}";
-				if (dir == JogDirection.Zup)
-					cmd += $"Z{step.ToString("0.0", NumberFormatInfo.InvariantInfo)}";
-
-				cmd += $"F{mPrenotedJogSpeed}";
-
-				EnqueueCommand(new GrblCommand("G91"));
-				EnqueueCommand(new GrblCommand(cmd));
-				EnqueueCommand(new GrblCommand("G90"));
-			}
-		}
-
-		private void EmulateJogV09(PointF target) //emulate jog using plane G-Code
-		{
-			string cmd = "G0";
-
-			cmd += $"X{target.X.ToString("0.00", NumberFormatInfo.InvariantInfo)}";
-			cmd += $"Y{target.Y.ToString("0.00", NumberFormatInfo.InvariantInfo)}";
-			cmd += $"F{mPrenotedJogSpeed}";
-
-			EnqueueCommand(new GrblCommand("G90"));
-			EnqueueCommand(new GrblCommand(cmd));
-		}
-
-		private void DoJogV11(JogDirection dir, decimal step)
-		{
-			if (ContinuosJogEnabled && dir != JogDirection.Zdown && dir != JogDirection.Zup) //se C.J. e non Z => prenotato
-			{
-				mPrenotedJogDirection = dir;
-				//lo step è quello configurato
-			}
-			else //non è CJ o non è Z => immediate enqueue jog command
-			{
-				mPrenotedJogDirection = JogDirection.None;
-				if (dir == JogDirection.Home)
-					EnqueueCommand(new GrblCommand(string.Format("$J=G90X0Y0F{0}", mPrenotedJogSpeed)));
-				else
-					EnqueueCommand(GetRelativeJogCommandv11(dir, step));
-			}
-		}
-
-		private void DoJogV11(PointF target)
-		{
-			mPrenotedJogDirection = JogDirection.None;
-			SendImmediate(0x85); //abort previous jog
-			EnqueueCommand(new GrblCommand(string.Format("$J=G90X{0}Y{1}F{2}", target.X.ToString("0.00", NumberFormatInfo.InvariantInfo), target.Y.ToString("0.00", NumberFormatInfo.InvariantInfo), mPrenotedJogSpeed)));
-		}
-
-		private GrblCommand GetRelativeJogCommandv11(JogDirection dir, decimal step)
-		{
-			string cmd = "$J=G91";
-			if (dir == JogDirection.NE || dir == JogDirection.E || dir == JogDirection.SE)
-				cmd += $"X{step.ToString("0.0", NumberFormatInfo.InvariantInfo)}";
-			if (dir == JogDirection.NW || dir == JogDirection.W || dir == JogDirection.SW)
-				cmd += $"X-{step.ToString("0.0", NumberFormatInfo.InvariantInfo)}";
-			if (dir == JogDirection.NW || dir == JogDirection.N || dir == JogDirection.NE)
-				cmd += $"Y{step.ToString("0.0", NumberFormatInfo.InvariantInfo)}";
-			if (dir == JogDirection.SW || dir == JogDirection.S || dir == JogDirection.SE)
-				cmd += $"Y-{step.ToString("0.0", NumberFormatInfo.InvariantInfo)}";
-			if (dir == JogDirection.Zdown)
-				cmd += $"Z-{step.ToString("0.0", NumberFormatInfo.InvariantInfo)}";
-			if (dir == JogDirection.Zup)
-				cmd += $"Z{step.ToString("0.0", NumberFormatInfo.InvariantInfo)}";
-
-			cmd += $"F{mPrenotedJogSpeed}";
-			return new GrblCommand(cmd);
-		}
-
-		private GrblCommand GetContinuosJogCommandv11(JogDirection dir)
-		{
-			string cmd = "$J=G53";
-			if (dir == JogDirection.NE || dir == JogDirection.E || dir == JogDirection.SE)
-				cmd += $"X{Configuration.TableWidth.ToString("0.0", NumberFormatInfo.InvariantInfo)}";
-			if (dir == JogDirection.NW || dir == JogDirection.W || dir == JogDirection.SW)
-				cmd += $"X{0.ToString("0.0", NumberFormatInfo.InvariantInfo)}";
-			if (dir == JogDirection.NW || dir == JogDirection.N || dir == JogDirection.NE)
-				cmd += $"Y{Configuration.TableHeight.ToString("0.0", NumberFormatInfo.InvariantInfo)}";
-			if (dir == JogDirection.SW || dir == JogDirection.S || dir == JogDirection.SE)
-				cmd += $"Y{0.ToString("0.0", NumberFormatInfo.InvariantInfo)}";
-			cmd += $"F{mPrenotedJogSpeed}";
-			return new GrblCommand(cmd);
-		}
-
-		public void EndJogV11() //da chiamare su ButtonUp
-		{
-			mPrenotedJogDirection = JogDirection.Abort;
-		}
-
-		private void PushJogCommand()
-		{
-			if (SupportTrueJogging && mPrenotedJogDirection != JogDirection.None && mPending.Count == 0)
-			{
-				if (mPrenotedJogDirection == JogDirection.Abort)
-				{
-					if (ContinuosJogEnabled)
-						SendImmediate(0x85);
-				}
-				else if (mPrenotedJogDirection == JogDirection.Home)
-				{
-					EnqueueCommand(new GrblCommand(string.Format("$J=G90X0Y0F{0}", mPrenotedJogSpeed)));
-				}
-				else
-				{
-					if (ContinuosJogEnabled)
-						EnqueueCommand(GetContinuosJogCommandv11(mPrenotedJogDirection));
-					else
-						EnqueueCommand(GetRelativeJogCommandv11(mPrenotedJogDirection, JogStep));
-				}
-
-				mPrenotedJogDirection = JogDirection.None;
-			}
-		}
-
-
-		private void StartTX()
-		{
-			lock (this)
-			{
-				// No soft reset when opening COM port for smoothieware
-				if (Type != Firmware.Smoothie)
-					InternalReset(Settings.GetObject("Reset Grbl On Connect", true));
-
-				InitializeBoard();
-				QueryTimer.Start();
-			}
-		}
-
-		protected virtual void InitializeBoard()
-		{
-			QueryPosition();
-		}
-
-		protected void ThreadTX()
-		{
-			lock (this)
-			{
-				try
-				{
-					if (MachineStatus == MacStatus.Connecting && Tools.HiResTimer.TotalMilliseconds - connectStart > 10000)
-						OnConnectTimeout();
-
-					if (!TX.MustExitTH())
-					{
-						PushJogCommand();
-
-						if (CanSend())
-							SendLine();
-
-						ManageCoolingCycles();
-					}
-
-					if (QueryTimer.Expired)
-						QueryPosition();
-
-					DetectHang();
-
-					TX.SleepTime = CanSend() ? CurrentThreadingMode.TxShort : CurrentThreadingMode.TxLong;
-					QueryTimer.Period = TimeSpan.FromMilliseconds(CurrentThreadingMode.StatusQuery);
-				}
-				catch (Exception ex)
-				{ Logger.LogException("ThreadTX", ex); }
-			}
-		}
-
-		// Override by Marlin
-		protected virtual void DetectHang()
-		{
-			if (mTP.LastIssue == DetectedIssue.Unknown && MachineStatus == MacStatus.Run && InProgram)
-			{
-				//bool executingM4 = false;
-				//if (HasPendingCommand())
-				//{
-				//	GrblCommand cur = mPending.Peek();
-				//	cur.BuildHelper();
-				//	executingM4 = cur.IsPause;
-				//	cur.DeleteHelper();
-				//}
-
-				bool noQueryResponse = debugLastStatusDelay.ElapsedTime > TimeSpan.FromTicks(QueryTimer.Period.Ticks * 10) && debugLastStatusDelay.ElapsedTime > TimeSpan.FromSeconds(5);
-				//bool noMovement = !executingM4 && debugLastMoveDelay.ElapsedTime > TimeSpan.FromSeconds(10);
-
-				if (noQueryResponse)
-					SetIssue(DetectedIssue.StopResponding);
-
-				//else if (noMovement)
-				//	SetIssue(DetectedIssue.StopMoving);
-			}
-		}
-
-
-		private void OnConnectTimeout()
-		{
-			if (com.IsOpen)
-			{
-				Logger.LogMessage("OpenCom", "Connection timeout!");
-				com.Close(true); //this cause disconnection from RX thread ("ReadLineOrDisconnect")
-			}
-		}
-
-		private bool CanSend()
-		{
-			GrblCommand next = PeekNextCommand();
-			return next != null && HasSpaceInBuffer(next);
-		}
-
-		private bool BufferIsFull()
-		{
-			GrblCommand next = PeekNextCommand();
-			return mUsedBuffer > 0 && next != null && !HasSpaceInBuffer(next);
-		}
-
-		private GrblCommand PeekNextCommand()
-		{
-			if (HasPendingCommands() && mPending.Peek().IsWriteEEPROM) //if managing eeprom write act like sync
-				return null;
-			else if (CurrentStreamingMode == StreamingMode.Buffered && mQueuePtr.Count > 0) //sono buffered e ho roba da trasmettere
-				return mQueuePtr.Peek();
-			else if (CurrentStreamingMode != StreamingMode.Buffered && mPending.Count == 0) //sono sync e sono vuoto
-				if (mRetryQueue != null) return mRetryQueue;
-				else if (mQueuePtr.Count > 0) return mQueuePtr.Peek();
-				else return null;
-			else
-				return null;
-		}
-
-		private void RemoveManagedCommand()
-		{
-			if (mRetryQueue != null)
-				mRetryQueue = null;
-			else
-				mQueuePtr.Dequeue();
-		}
-
-		protected virtual bool HasSpaceInBuffer(GrblCommand command)
-		{ return (mUsedBuffer + command.SerialData.Length) <= BufferSize; }
-
-		private void SendLine()
-		{
-			GrblCommand tosend = PeekNextCommand();
-			if (tosend != null)
-			{
-				try
-				{
-					tosend.BuildHelper();
-
-					tosend.SetSending();
-					mSentPtr.Add(tosend);
-					mPending.Enqueue(tosend);
-					RemoveManagedCommand();
-
-					SendToSerial(tosend);
-
-					if (mTP.InProgram)
-						mTP.JobSent();
-
-					debugLastMoveOrActivityDelay.Start();
-				}
-				catch (Exception ex)
-				{
-					if (tosend != null) Logger.LogMessage("SendLine", "Error sending [{0}] command: {1}", tosend.Command, ex.Message);
-					//Logger.LogException("SendLine", ex);
-				}
-				finally { tosend.DeleteHelper(); }
-			}
-		}
-
-		protected virtual void SendToSerial(GrblCommand tosend)
-		{
-			mUsedBuffer += tosend.SerialData.Length;
-			com.Write(tosend.SerialData); //invio dei dati alla linea di comunicazione
-		}
-
-		public int UsedBuffer
-		{ get { return mUsedBuffer; } }
-
-		public int FreeBuffer
-		{ get { return BufferSize - mUsedBuffer; } }
-
-		public virtual int BufferSize
-		{ get { return mAutoBufferSize; } }
-
-		public int GrblBlock
-		{ get { return mGrblBlocks; } }
-
-		public int GrblBuffer
-		{ get { return mGrblBuffer; } }
-
-		void ThreadRX()
-		{
-			try
-			{
-				string rline = null;
-				if ((rline = WaitComLineOrDisconnect()) != null)
-				{
-					lock (this)
-					{
-						ManageReceivedLine(rline);
-						HandleMissingOK();
-					}
-				}
-
-				RX.SleepTime = HasIncomingData() ? CurrentThreadingMode.RxShort : CurrentThreadingMode.RxLong;
-			}
-			catch (Exception ex)
-			{ Logger.LogException("ThreadRX", ex); }
-		}
-
-		// this function try to detect and automatically unlock from a "buffer stuck" condition
-		// a "buffer stuck" condition occurs when LaserGRBL does not receive some "ok's" 
-		// back from grbl (i.e. because of electrical noise on wire) and so LaserGRBL
-		// does no longer send commands anymore because think the buffer is full
-		// this feature can work only if $10=3 (status report with buffer size report enabled)
-		private void HandleMissingOK()
-		{
-			if (IsBufferStuck() && MachineSayBufferFree())
-				UnlockFromBufferStuck(true);
-		}
-
-		public void UnlockFromBufferStuck(bool auto)
-		{
-			if (IsBufferStuck())
-				CreateFakeOK(mPending.Count, auto); //rispondi "ok" a tutti i comandi pending
-		}
-
-		public bool IsBufferStuck()
-		{
-			return MachineStatus == MacStatus.Run && HasPendingCommands() && !BufferIsFree() && MachineNotMovingOrReply();
-		}
-
-		private void CreateFakeOK(int count, bool auto)
-		{
-			mSentPtr.Add(new GrblMessage("Unlock from buffer stuck!", false));
-			string act = auto ? "auto" : "manual";
-
-			ComWrapper.ComLogger.Log("com", $"Handle Missing OK [{count}] ({act})");
-			Logger.LogMessage("Issue detector", $"Handle Missing OK [{count}] ({act})");
-
-			for (int i = 0; i < count; i++)
-				ManageCommandResponse("ok");
-		}
-
-		private bool MachineNotMovingOrReply() => debugLastMoveOrActivityDelay.ElapsedTime > TimeSpan.FromSeconds(10);
-		private bool MachineSayBufferFree() => mGrblBuffer == BufferSize;
-		private bool BufferIsFree() => mUsedBuffer == 0;
-		private bool HasPendingCommands() => mPending.Count > 0;
-
-		protected virtual void ManageReceivedLine(string rline)
-		{
-			if (IsCommandReplyMessage(rline))
-				ManageCommandResponse(rline);
-			else if (IsRealtimeStatusMessage(rline))
-				ManageRealTimeStatus(rline);
-			else if (IsGrblHalWelcomeMessage(rline))
-				ManageGrblHalWelcomeMessage(rline);
-			else if (IsVigoWelcomeMessage(rline))
-				ManageVigoWelcomeMessage(rline);
-			else if (IsOrturModelMessage(rline))
-				ManageOrturModelMessage(rline);
-			else if (IsAuferoModelMessage(rline))
-				ManageOrturModelMessage(rline);
-			else if (IsOrturFirmwareMessage(rline))
-				ManageOrturFirmwareMessage(rline);
-			else if (IsStandardWelcomeMessage(rline))
-				ManageStandardWelcomeMessage(rline);
-			else if (IsBrokenOkMessage(rline))
-				ManageBrokenOkMessage(rline);
-			else if (IsStandardBlockingAlarm(rline))
-				ManageStandardBlockingAlarm(rline);
-			else if (IsStaIPMessage(rline))
-				ManageStaIPMessage(rline);
-			//else if (IsOrturBlockingAlarm(rline))
-			//	ManageOrturBlockingAlarm(rline);
-			else
-				ManageGenericMessage(rline);
-		}
-
-		private void ManageStaIPMessage(string rline)
-		{
-			try
-			{
-				//[MSG:Get IP 192.168.1.182]
-				mDetectedIP = rline.Substring(12, rline.Length - 1 - 12);
-				ManageGenericMessage(rline); //process as usual
-			}
-			catch (Exception ex)
-			{
-				Logger.LogMessage("IP Detector", "Ex on [{0}] message", rline);
-				Logger.LogException("IP Detector", ex);
-			}
-		}
-
-		private bool IsCommandReplyMessage(string rline) => rline.ToLower().StartsWith("ok") || rline.ToLower().StartsWith("error");
-		private bool IsRealtimeStatusMessage(string rline) => rline.StartsWith("<") && rline.EndsWith(">");
-		private bool IsGrblHalWelcomeMessage(string rline) => rline.StartsWith("GrblHAL");
-		private bool IsVigoWelcomeMessage(string rline) => rline.StartsWith("Grbl-Vigo");
-		private bool IsOrturModelMessage(string rline) => rline.StartsWith("Ortur ");
-		private bool IsAuferoModelMessage(string rline) => rline.StartsWith("Aufero ");
-		private bool IsOrturFirmwareMessage(string rline) => rline.StartsWith("OLF");
-		private bool IsStandardWelcomeMessage(string rline) => rline.StartsWith("Grbl");
-		private bool IsBrokenOkMessage(string rline) => rline.ToLower().Contains("ok");
-		private bool IsStandardBlockingAlarm(string rline) => rline.ToLower().StartsWith("alarm:");
-		private bool IsIVerMessage(string rline) => rline.StartsWith("[VER:") && rline.EndsWith("]");
-		private bool IsIOptMessage(string rline) => rline.StartsWith("[OPT:") && rline.EndsWith("]");
-		private bool IsStaIPMessage(string rline) => rline.StartsWith("[MSG:Get IP ") && rline.EndsWith("]");
-		private bool IsOrturBlockingAlarm(string rline) => false;
-
-		private void ManageGenericMessage(string rline)
-		{
-			try { mSentPtr.Add(new GrblMessage(rline, SupportCSV)); }
-			catch (Exception ex)
-			{
-				Logger.LogMessage("GenericMessage", "Ex on [{0}] message", rline);
-				Logger.LogException("GenericMessage", ex);
-			}
-		}
-
-		private void ManageStandardBlockingAlarm(string rline)
-		{
-			if (mTP.LastIssue == DetectedIssue.Unknown && InProgram)
-				SetIssue(DetectedIssue.MachineAlarm);
-
-			ManageGenericMessage(rline); //process as usual
-		}
-
-		private void ManageOrturBlockingAlarm(string rline)
-		{
-			ManageGenericMessage(rline); //process as usual
-		}
-
-		private void ManageStandardWelcomeMessage(string rline)
-		{
-			//Grbl X.Xx ['$' for help]
-			try
-			{
-				int maj = int.Parse(rline.Substring(5, 1));
-				int min = int.Parse(rline.Substring(7, 1));
-				char build = rline.Substring(8, 1).ToCharArray()[0];
-				GrblVersion = new GrblVersionInfo(maj, min, build, mWelcomeSeen, mVersionSeen, false);
-
-				DetectUnexpectedReset();
-				OnStartupMessage();
-			}
-			catch (Exception ex)
-			{
-				Logger.LogMessage("VersionInfo", "Ex on [{0}] message", rline);
-				Logger.LogException("VersionInfo", ex);
-			}
-			mSentPtr.Add(new GrblMessage(rline, false));
-		}
-
-		private void ManageGrblHalWelcomeMessage(string rline)
-		{
-			//GrblHAL X.Xx ['$' or '$HELP' for help]
-			try
-			{
-				int maj = int.Parse(rline.Substring(8, 1));
-				int min = int.Parse(rline.Substring(10, 1));
-				char build = rline.Substring(11, 1).ToCharArray()[0];
-				GrblVersion = new GrblVersionInfo(maj, min, build, mWelcomeSeen, mVersionSeen, true);
-
-				DetectUnexpectedReset();
-				OnStartupMessage();
-			}
-			catch (Exception ex)
-			{
-				Logger.LogMessage("VersionInfo", "Ex on [{0}] message", rline);
-				Logger.LogException("VersionInfo", ex);
-			}
-			mSentPtr.Add(new GrblMessage(rline, false));
-		}
-
-		private void ManageVigoWelcomeMessage(string rline)
-		{
-			//Grbl-Vigo:1.1f|Build:G-20170131-V3.0-20200720
-			try
-			{
-				int maj = int.Parse(rline.Substring(10, 1));
-				int min = int.Parse(rline.Substring(12, 1));
-				char build = rline.Substring(13, 1).ToCharArray()[0];
-				string VendorVersion = rline.Split(':')[2];
-				GrblVersion = new GrblVersionInfo(maj, min, build, "Vigotec", VendorVersion, false);
-				Logger.LogMessage("VigoInfo", "Detected {0}", VendorVersion);
-
-				DetectUnexpectedReset();
-				OnStartupMessage();
-			}
-			catch (Exception ex)
-			{
-				Logger.LogMessage("VersionInfo", "Ex on [{0}] message", rline);
-				Logger.LogException("VersionInfo", ex);
-			}
-			mSentPtr.Add(new GrblMessage(rline, false));
-		}
-
-		private void ManageOrturModelMessage(string rline)
-		{
-			try
-			{
-				mWelcomeSeen = rline;
-				mWelcomeSeen = mWelcomeSeen.Replace("Ready", "");
-				mWelcomeSeen = mWelcomeSeen.Replace("!", "");
-				mWelcomeSeen = mWelcomeSeen.Trim();
-				Logger.LogMessage("OrturInfo", "Detected {0}", mWelcomeSeen);
-			}
-			catch (Exception ex)
-			{
-				Logger.LogMessage("OrturInfo", "Ex on [{0}] message", rline);
-				Logger.LogException("OrturInfo", ex);
-			}
-			mSentPtr.Add(new GrblMessage(rline, false));
-		}
-
-		private void ManageOrturFirmwareMessage(string rline)
-		{
-			try
-			{
-				mVersionSeen = rline;
-				mVersionSeen = mVersionSeen.Replace("OLF", "");
-				mVersionSeen = mVersionSeen.Trim(new char[] { '.', ' ', ':' });
-				Logger.LogMessage("OrturInfo", "Detected OLF {0}", mVersionSeen);
-			}
-			catch (Exception ex)
-			{
-				Logger.LogMessage("OrturInfo", "Ex on [{0}] message", rline);
-				Logger.LogException("OrturInfo", ex);
-			}
-			mSentPtr.Add(new GrblMessage(rline, false));
-		}
-
-		private void OnStartupMessage() //resetta tutto, così funziona anche nel caso di hard-unexpected reset
-		{
-			lock (this)
-			{
-				ClearQueue(false);
-				mUsedBuffer = 0;
-				mTP.JobEnd(true);
-				mCurOvLinear = mCurOvRapids = mCurOvPower = 100;
-				mTarOvLinear = mTarOvRapids = mTarOvPower = 100;
-			}
-			RiseOverrideChanged();
-		}
-
-		private void DetectUnexpectedReset()
-		{
-			if (mTP.LastIssue == DetectedIssue.Unknown && MachineStatus == MacStatus.Run && InProgram)
-				SetIssue(DetectedIssue.UnexpectedReset);
-		}
-
-		private GrblVersionInfo StatusReportVersion(string rline)
-		{
-			//if version is known -> return version
-			if (GrblVersion != null)
-				return GrblVersion;
-
-			//else guess from rline
-			//the check of Pin: is due to compatibility with 1.0c https://github.com/arkypita/LaserGRBL/issues/317
-			if (rline.Contains("|") && !rline.Contains("Pin:"))
-				return new GrblVersionInfo(1, 1);
-			else if (rline.Contains("|") && rline.Contains("Pin:"))
-				return new GrblVersionInfo(1, 0, 'c');
-			else
-				return new GrblVersionInfo(0, 9);
-		}
-
-		private void ManageRealTimeStatus(string rline)
-		{
-			try
-			{
-				debugLastStatusDelay.Start();
-
-				rline = rline.Substring(1, rline.Length - 2);
-
-				GrblVersionInfo rversion = StatusReportVersion(rline);
-				if (rversion >= new GrblVersionInfo(1, 1))
-				{
-					//grbl > 1.1 - https://github.com/gnea/grbl/wiki/Grbl-v1.1-Interface#real-time-status-reports
-					string[] arr = rline.Split("|".ToCharArray());
-
-					ParseMachineStatus(arr[0]);
-
-					for (int i = 1; i < arr.Length; i++)
-					{
-						if (arr[i].StartsWith("Ov:"))
-							ParseOverrides(arr[i]);
-						else if (arr[i].StartsWith("Bf:"))
-							ParseBf(arr[i]);
-						else if (arr[i].StartsWith("WPos:"))
-							ParseWPos(arr[i]);
-						else if (arr[i].StartsWith("MPos:"))
-							ParseMPos(arr[i]);
-						else if (arr[i].StartsWith("WCO:"))
-							ParseWCO(arr[i]);
-						else if (arr[i].StartsWith("FS:"))
-							ParseFS(arr[i]);
-						else if (arr[i].StartsWith("F:"))
-							ParseF(arr[i]);
-					}
-				}
-				else //<Idle,MPos:0.000,0.000,0.000,WPos:0.000,0.000,0.000>
-				{
-					string[] arr = rline.Split(",".ToCharArray());
-
-					if (arr.Length > 0)
-						ParseMachineStatus(arr[0]);
-					if (arr.Length > 3)
-						SetMPosition(new GPoint(float.Parse(arr[1].Substring(5, arr[1].Length - 5), System.Globalization.NumberFormatInfo.InvariantInfo), float.Parse(arr[2], System.Globalization.NumberFormatInfo.InvariantInfo), float.Parse(arr[3], System.Globalization.NumberFormatInfo.InvariantInfo)));
-					if (arr.Length > 6)
-						ComputeWCO(new GPoint(float.Parse(arr[4].Substring(5, arr[4].Length - 5), System.Globalization.NumberFormatInfo.InvariantInfo), float.Parse(arr[5], System.Globalization.NumberFormatInfo.InvariantInfo), float.Parse(arr[6], System.Globalization.NumberFormatInfo.InvariantInfo)));
-				}
-			}
-			catch (Exception ex)
-			{
-				Logger.LogMessage("RealTimeStatus", "Ex on [{0}] message", rline);
-				Logger.LogException("RealTimeStatus", ex);
-			}
-		}
-
-		private void ComputeWCO(GPoint wpos) //WCO = MPos - WPos
-		{
-			SetWCO(mMPos - wpos);
-		}
-
-		private void ParseWCO(string p)
-		{
-			string wco = p.Substring(4, p.Length - 4);
-			string[] xyz = wco.Split(",".ToCharArray());
-			SetWCO(new GPoint(ParseFloat(xyz, 0), ParseFloat(xyz, 1), ParseFloat(xyz, 2)));
-		}
-
-		private void ParseWPos(string p)
-		{
-			string wpos = p.Substring(5, p.Length - 5);
-			string[] xyz = wpos.Split(",".ToCharArray());
-			SetMPosition(mWCO + new GPoint(ParseFloat(xyz, 0), ParseFloat(xyz, 1), ParseFloat(xyz, 2)));
-		}
-
-		private void ParseMPos(string p)
-		{
-			string mpos = p.Substring(5, p.Length - 5);
-			string[] xyz = mpos.Split(",".ToCharArray());
-			SetMPosition(new GPoint(ParseFloat(xyz, 0), ParseFloat(xyz, 1), ParseFloat(xyz, 2)));
-		}
-
-		protected static float ParseFloat(string value)
-		{
-			return float.Parse(value, NumberFormatInfo.InvariantInfo);
-		}
-
-		protected static float ParseFloat(string[] arr, int idx, float defval = 0.0f)
-		{
-			if (arr == null || idx < 0 || idx >= arr.Length) return defval;
-			return float.Parse(arr[idx], NumberFormatInfo.InvariantInfo);
-		}
-
-		private void ParseBf(string p)
-		{
-			string bf = p.Substring(3, p.Length - 3);
-			string[] ab = bf.Split(",".ToCharArray());
-
-			mGrblBlocks = int.Parse(ab[0]);
-			mGrblBuffer = int.Parse(ab[1]);
-
-			EnlargeBuffer(mGrblBuffer, false); //do not force here, we cannot rely on values received from report (electrical noise?!)
-		}
-
-		private void EnlargeBuffer(int newval, bool force)
-		{
-			int oldval = mAutoBufferSize;
-
-			if (force) //this came from $I at connect, and so it is a verified buffer size
-			{
-				mAutoBufferSize = newval;
-			}
-			else if (mAutoBufferSize == DEFAULT_BUFFER_SIZE)
-			{
-				// act only to change default value at first event
-				// do not re-act without a new connect
-				// only allow known values (do not accept error in bf message caused by electrical noise)
-
-				if (newval == 128) //Grbl v1.1 with enabled buffer report
-					mAutoBufferSize = 128;
-				else if (newval == 255) //Grbl-Mega fixed
-					mAutoBufferSize = 255;
-				else if (newval == 256) //Grbl-Mega
-					mAutoBufferSize = 256;
-				else if (newval == 10240) //Grbl-LPC
-					mAutoBufferSize = 10240;
-				else if (newval == 254) //Ortur
-					mAutoBufferSize = 254;
-			}
-
-			if (mAutoBufferSize != oldval)
-				Logger.LogMessage("EnlargeBuffer", "Buffer size changed to {0} [{1}]", mAutoBufferSize, force);
-		}
-
-		private void ParseFS(string p)
-		{
-			string sfs = p.Substring(3, p.Length - 3);
-			string[] fs = sfs.Split(",".ToCharArray());
-			SetFS(ParseFloat(fs, 0), ParseFloat(fs, 1));
-		}
-
-		protected virtual void ParseF(string p)
-		{
-			string f = p.Substring(2, p.Length - 2);
-			SetFS(ParseFloat(f), 0);
-		}
-
-		protected void SetFS(float f, float s)
-		{
-			LaserLifeHandler.ComputeLaserTrueTime(mCurS);
-			mCurF = f;
-			mCurS = s;
-		}
-
-
-		protected void SetMPosition(GPoint pos)
-		{
-			if (pos != mMPos)
-			{
-				mMPos = pos;
-				debugLastMoveOrActivityDelay.Start();
-			}
-		}
-
-		private void SetWCO(GPoint wco)
-		{
-			mWCO = wco;
-			mTP.LastKnownWCO = wco; //remember last wco for job resume
-		}
-
-
-		protected void ManageBrokenOkMessage(string rline) //
-		{
-			mSentPtr.Add(new GrblMessage("Handle broken ok!", false));
-			Logger.LogMessage("CommandResponse", "Broken \"ok\" message: [{0}]", rline);
-			ManageCommandResponse("ok");
-		}
-
-		protected void ManageCommandResponse(string rline)
-		{
-			try
-			{
-				debugLastMoveOrActivityDelay.Start(); //add a reset to prevent HangDetector trigger on G4
-				if (HasPendingCommands())
-				{
-					GrblCommand pending = mPending.Peek();  //necessario fare peek
-					pending.SetResult(rline, SupportCSV);   //assegnare lo stato
-					mPending.Dequeue();                     //solo alla fine rimuoverlo dalla lista (per write config che si aspetta che lo stato sia noto non appena la coda si svuota)
-
-					mUsedBuffer = Math.Max(0, mUsedBuffer - pending.SerialData.Length);
-
-					if (mTP.InProgram && pending.RepeatCount == 0) //solo se non è una ripetizione aggiorna il tempo
-						mTP.JobExecuted(pending.TimeOffset);
-
-					if (mTP.InProgram && pending.Status == GrblCommand.CommandStatus.ResponseBad)
-						mTP.JobError(); //incrementa il contatore
-
-					if (pending.IsWriteEEPROM && pending.Status == GrblCommand.CommandStatus.ResponseGood)
-						Configuration.AddOrUpdate(pending.GetDecodedMessage());
-
-					//ripeti errori programma && non ho una coda (magari mi sto allineando per cambio conf buff/sync) && ho un errore && non l'ho già ripetuto troppe volte
-					if (InProgram && CurrentStreamingMode == StreamingMode.RepeatOnError && mPending.Count == 0 && pending.Status == GrblCommand.CommandStatus.ResponseBad && pending.RepeatCount < 3) //il comando eseguito ha dato errore
-						mRetryQueue = new GrblCommand(pending.Command, pending.RepeatCount + 1); //repeat on error
-				}
-
-				if (InProgram && mQueuePtr.Count == 0 && mPending.Count == 0)
-					OnProgramEnd();
-			}
-			catch (Exception ex)
-			{
-				Logger.LogMessage("CommandResponse", "Ex on [{0}] message", rline);
-				Logger.LogException("CommandResponse", ex);
-			}
-		}
-
-		protected static char[] trimarray = new char[] { '\r', '\n', ' ' };
-		private string WaitComLineOrDisconnect()
-		{
-			try
-			{
-				string rv = com.ReadLineBlocking();
-				rv = rv.TrimEnd(trimarray); //rimuovi ritorno a capo
-				rv = rv.Trim(); //rimuovi spazi iniziali e finali
-				return rv.Length > 0 ? rv : null;
-			}
-			catch
-			{
-				try { CloseCom(false); }
-				catch { }
-				return null;
-			}
-		}
-
-		private bool HasIncomingData()
-		{
-			try
-			{
-				return com.HasData();
-			}
-			catch
-			{
-				try { CloseCom(false); }
-				catch { }
-				return false;
-			}
-		}
-
-		public void ManageOverrides()
-		{
-			if (mTarOvLinear == 100 && mCurOvLinear != 100) //devo fare un reset
-				SendImmediate(144);
-			else if (mTarOvLinear - mCurOvLinear >= 10) //devo fare un bigstep +
-				SendImmediate(145);
-			else if (mCurOvLinear - mTarOvLinear >= 10) //devo fare un bigstep -
-				SendImmediate(146);
-			else if (mTarOvLinear - mCurOvLinear >= 1) //devo fare uno smallstep +
-				SendImmediate(147);
-			else if (mCurOvLinear - mTarOvLinear >= 1) //devo fare uno smallstep -
-				SendImmediate(148);
-
-			if (mTarOvPower == 100 && mCurOvPower != 100) //devo fare un reset
-				SendImmediate(153);
-			else if (mTarOvPower - mCurOvPower >= 10) //devo fare un bigstep +
-				SendImmediate(154);
-			else if (mCurOvPower - mTarOvPower >= 10) //devo fare un bigstep -
-				SendImmediate(155);
-			else if (mTarOvPower - mCurOvPower >= 1) //devo fare uno smallstep +
-				SendImmediate(156);
-			else if (mCurOvPower - mTarOvPower >= 1) //devo fare uno smallstep -
-				SendImmediate(157);
-
-			if (mTarOvRapids == 100 && mCurOvRapids != 100)
-				SendImmediate(149);
-			else if (mTarOvRapids == 50 && mCurOvRapids != 50)
-				SendImmediate(150);
-			else if (mTarOvRapids == 25 && mCurOvRapids != 25)
-				SendImmediate(151);
-		}
-
-		private void ParseOverrides(string data)
-		{
-			//Ov:100,100,100
-			//indicates current override values in percent of programmed values
-			//for feed, rapids, and spindle speed, respectively.
-
-			data = data.Substring(data.IndexOf(':') + 1);
-			string[] arr = data.Split(",".ToCharArray());
-
-			ChangeOverrides(int.Parse(arr[0]), int.Parse(arr[1]), int.Parse(arr[2]));
-			ManageOverrides();
-		}
-
-		private void ChangeOverrides(int feed, int rapids, int spindle)
-		{
-			bool notify = (feed != mCurOvLinear || rapids != mCurOvRapids || spindle != mCurOvPower);
-			mCurOvLinear = feed;
-			mCurOvRapids = rapids;
-			mCurOvPower = spindle;
-
-			if (notify)
-				RiseOverrideChanged();
-		}
-
-		public int OverrideG1
-		{ get { return mCurOvLinear; } }
-
-		public int OverrideG0
-		{ get { return mCurOvRapids; } }
-
-		public int OverrideS
-		{ get { return mCurOvPower; } }
-
-		public int TOverrideG1
-		{
-			get { return mTarOvLinear; }
-			set { mTarOvLinear = value; }
-		}
-
-		public int TOverrideG0
-		{
-			get { return mTarOvRapids; }
-			set { mTarOvRapids = value; }
-		}
-
-		public int TOverrideS
-		{
-			get { return mTarOvPower; }
-			set { mTarOvPower = value; }
-		}
-
-		protected virtual void ParseMachineStatus(string data)
-		{
-			if (data.Contains(":"))
-				data = data.Substring(0, data.IndexOf(':'));
-
-			MacStatus var = (MacStatus)Enum.Parse(typeof(MacStatus), data);
-
-			if (InProgram && var == MacStatus.Idle) //bugfix for grbl sending Idle on G4
-				var = MacStatus.Run;
-
-			if (var == MacStatus.Hold && mHoldByCoolingRequest)
-				var = MacStatus.Cooling;
-			else if (var == MacStatus.Hold && !mHoldByUserRequest)
-				var = MacStatus.AutoHold;
-
-			SetStatus(var);
-		}
-
-
-		protected virtual void ForceStatusIdle() { } // Used by Marlin to update status to Idle (As Marlin has no immediate message)
-
-		private void OnProgramEnd()
-		{
-			if (mTP.JobEnd(mLoopCount == 1) && mLoopCount > 1 && mMachineStatus != MacStatus.Check)
-			{
-				Logger.LogMessage("CycleEnd", "Cycle Executed: {0} lines, {1} errors, {2}", file.Count, mTP.ErrorCount, Tools.Utils.TimeSpanToString(ProgramTime, Tools.Utils.TimePrecision.Second, Tools.Utils.TimePrecision.Second, ",", true));
-				mSentPtr.Add(new GrblMessage(string.Format("[{0} lines, {1} errors, {2}]", file.Count, mTP.ErrorCount, Tools.Utils.TimeSpanToString(ProgramTime, Tools.Utils.TimePrecision.Second, Tools.Utils.TimePrecision.Second, ",", true)), false));
-
-				LoopCount--;
-				RunProgramFromStart(false, false, true);
-			}
-			else
-			{
-				Logger.LogMessage("ProgramEnd", "Job Executed: {0} lines, {1} errors, {2}", file.Count, mTP.ErrorCount, Tools.Utils.TimeSpanToString(ProgramTime, Tools.Utils.TimePrecision.Second, Tools.Utils.TimePrecision.Second, ",", true));
-				mSentPtr.Add(new GrblMessage(string.Format("[{0} lines, {1} errors, {2}]", file.Count, mTP.ErrorCount, Tools.Utils.TimeSpanToString(ProgramTime, Tools.Utils.TimePrecision.Second, Tools.Utils.TimePrecision.Second, ",", true)), false));
-
-				OnJobEnd();
-
-				SoundEvent.PlaySound(SoundEvent.EventId.Success);
-
-				if (ProgramGlobalTime.TotalMinutes >= (int)Settings.GetObject("TelegramNotification.Threshold", 1))
-					Telegram.NotifyEvent(String.Format("<b>Job Executed</b>\n{0} lines, {1} errors\nTime: {2}", file.Count, mTP.ErrorCount, Tools.Utils.TimeSpanToString(ProgramGlobalTime, Tools.Utils.TimePrecision.Second, Tools.Utils.TimePrecision.Second, ",", true)));
-
-				ForceStatusIdle();
-			}
-		}
-
-		private bool InPause
-		{ get { return mMachineStatus != MacStatus.Run && mMachineStatus != MacStatus.Idle; } }
-
-		private void ClearQueue(bool sent)
-		{
-			mQueue.Clear();
-			mPending.Clear();
-			if (sent) mSent.Clear();
-			mRetryQueue = null;
-		}
-
-		public bool CanReOpenFile
-		{
-			get
-			{
-				string lastFile = Settings.GetObject<string>("Core.LastOpenFile", null);
-				return CanLoadNewFile && lastFile != null && System.IO.File.Exists(lastFile);
-			}
-		}
-
-		public bool QueueEmpty { get { return mQueue.Count == 0; } }
-
-		public bool CanLoadNewFile
-		{ get { return !InProgram; } }
-
-		public bool CanSendFile
-		{ get { return IsConnected && HasProgram && IdleOrCheck && QueueEmpty && !mDoingSend; } }
-
-		public bool CanAbortProgram
-		{ get { return IsConnected && HasProgram && (MachineStatus == MacStatus.Run || IsAnyHoldState(MachineStatus)) || !QueueEmpty; } }
-
-		public bool CanImportExport
-		{ get { return IsConnected && MachineStatus == MacStatus.Idle; } }
-
-		public bool CanResetGrbl
-		{ get { return IsConnected && MachineStatus != MacStatus.Disconnected; } }
-
-		public bool CanSendManualCommand
-		{ get { return IsConnected && MachineStatus != MacStatus.Disconnected && !InProgram; } }
-
-		public bool CanDoHoming
-		{ get { return IsConnected && (MachineStatus == MacStatus.Idle || MachineStatus == GrblCore.MacStatus.Alarm) && Configuration.HomingEnabled; } }
-
-		public bool CanDoZeroing
-		{ get { return IsConnected && MachineStatus == MacStatus.Idle && WorkPosition != GPoint.Zero; } }
-
-		public bool CanUnlock
-		{ get { return IsConnected && (MachineStatus == MacStatus.Idle || MachineStatus == GrblCore.MacStatus.Alarm); } }
-
-		public bool CanFeedHold
-		{ get { return IsConnected && MachineStatus == MacStatus.Run; } }
-
-		public bool CanResumeHold
-		{ get { return IsConnected && (MachineStatus == MacStatus.Door || IsAnyHoldState(MachineStatus)); } }
-
-		public bool CanReadWriteConfig
-		{ get { return IsConnected && !InProgram && (MachineStatus == MacStatus.Idle || MachineStatus == MacStatus.Alarm); } }
-
-		public decimal LoopCount
-		{ get { return mLoopCount; } set { mLoopCount = value; if (OnLoopCountChange != null) OnLoopCountChange(mLoopCount); } }
-
-		private ThreadingMode CurrentThreadingMode
-		{ get { return Settings.GetObject("Threading Mode", ThreadingMode.UltraFast); } }
-
-		public virtual StreamingMode CurrentStreamingMode
-		{ get { return Settings.GetObject("Streaming Mode", StreamingMode.Buffered); } }
-
-		private bool IdleOrCheck
-		{ get { return MachineStatus == MacStatus.Idle || MachineStatus == MacStatus.Check; } }
-
-		public bool AutoCooling
-		{ get { return Settings.GetObject("AutoCooling", false) && SupportAutoCooling; } }
-		public bool SupportAutoCooling { get => GrblVersion != null && GrblVersion >= new GrblVersionInfo(1, 1) && Configuration != null && Configuration.LaserMode; }
-
-		public TimeSpan AutoCoolingOn
-		{ get { return Settings.GetObject("AutoCooling TOn", TimeSpan.FromMinutes(10)); } }
-
-		public TimeSpan AutoCoolingOff
-		{ get { return Settings.GetObject("AutoCooling TOff", TimeSpan.FromMinutes(1)); } }
-
-		private void ManageCoolingCycles()
-		{
-			if (AutoCooling && InProgram && MachineStatus != MacStatus.Hold && MachineStatus != MacStatus.AutoHold)
-				NowCooling = (ProgramGlobalTime.Ticks % (AutoCoolingOn + AutoCoolingOff).Ticks) > AutoCoolingOn.Ticks;
-		}
-
-		protected bool mHoldByUserRequest = false;
-		protected bool mHoldByCoolingRequest = false;
-		private bool mNowCooling = false;
-		private bool NowCooling
-		{
-			set
-			{
-				if (mNowCooling != value)
-				{
-					if (value)
-						StartCooling();
-					else
-						ResumeCooling();
-
-					mNowCooling = value;
-				}
-			}
-		}
-
-		private void StartCooling()
-		{
-			if (SupportLaserMode && Configuration.LaserMode)
-			{
-				FeedHold(true);
-			}
-			else //TODO: emulate pause by pushing laser off and sleep into stream
-			{
-
-			}
-		}
-
-		private void ResumeCooling()
-		{
-			if (SupportLaserMode && Configuration.LaserMode)
-			{
-				CycleStartResume(true);
-			}
-		}
-
-		private static string mDataPath;
-		public static string DataPath
-		{
-			get
-			{
-				if (mDataPath == null)
-				{
-					mDataPath = System.IO.Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "LaserGRBL");
-					if (!System.IO.Directory.Exists(mDataPath))
-						System.IO.Directory.CreateDirectory(mDataPath);
-				}
-
-				return mDataPath;
-			}
-		}
-
-		public static string ExePath
-		{
-			get { return System.IO.Path.GetDirectoryName(Application.ExecutablePath); }
-		}
-
-		private static string mTempPath;
-		public static string TempPath
-		{
-			get
-			{
-				if (mTempPath == null)
-				{
-					mTempPath = System.IO.Path.Combine(System.IO.Path.GetTempPath(), "LaserGRBL");
-					if (!System.IO.Directory.Exists(mTempPath))
-						System.IO.Directory.CreateDirectory(mTempPath);
-				}
-
-				return mTempPath;
-			}
-		}
-
-
-		public static string TranslateEnum(Enum value)
-		{
-			try
-			{
-				string rv = Strings.ResourceManager.GetString(value.GetType().Name + value.ToString());
-				return string.IsNullOrEmpty(rv) ? value.ToString() : rv;
-			}
-			catch { return value.ToString(); }
-		}
-
-
-		internal bool ManageHotKeys(Form parent, System.Windows.Forms.Keys keys)
-		{
-			if (SuspendHK)
-				return false;
-			else
-				return mHotKeyManager.ManageHotKeys(parent, keys);
-		}
-
-		internal void HKConnectDisconnect()
-		{
-			if (IsConnected)
-				HKDisconnect();
-			else
-				HKConnect();
-		}
-
-		internal void HKConnect()
-		{
-			if (!IsConnected)
-				OpenCom();
-		}
-
-		internal void HKDisconnect()
-		{
-			if (IsConnected)
-			{
-				if (!(InProgram && System.Windows.Forms.MessageBox.Show(Strings.DisconnectAnyway, Strings.WarnMessageBoxHeader, System.Windows.Forms.MessageBoxButtons.YesNo, System.Windows.Forms.MessageBoxIcon.Warning, System.Windows.Forms.MessageBoxDefaultButton.Button2) != System.Windows.Forms.DialogResult.Yes))
-					CloseCom(true);
-			}
-		}
-
-		internal void HelpOnLine()
-		{ Tools.Utils.OpenLink(@"https://lasergrbl.com/usage/"); }
-
-		internal void GrblHoming()
-		{ if (CanDoHoming) EnqueueCommand(new GrblCommand("$H")); }
-
-		internal void GrblUnlock()
-		{ if (CanUnlock) EnqueueCommand(new GrblCommand("$X")); }
-
-		internal void SetNewZero()
-		{ if (CanDoZeroing) EnqueueCommand(new GrblCommand("G92 X0 Y0 Z0")); }
-
-		public int JogSpeed { get; set; }
-		public decimal JogStep { get; set; }
-
-		public bool ContinuosJogEnabled { get { return Settings.GetObject("Enable Continuous Jog", false); } }
-
-		public bool SuspendHK { get; set; }
-
-		public HotKeysManager HotKeys { get { return mHotKeyManager; } }
-
-		internal void WriteHotkeys(System.Collections.Generic.List<HotKeysManager.HotKey> mLocalList)
-		{
-			mHotKeyManager.Clear();
-			mHotKeyManager.AddRange(mLocalList);
-			Settings.SetObject("Hotkey Setup", mHotKeyManager);
-		}
-
-		//internal void HKCustomButton(int index)
-		//{
-		//	CustomButton cb = CustomButtons.GetButton(index);
-		//	if (cb != null && cb.EnabledNow(this))
-		//		ExecuteCustombutton(cb.GCode);
-		//}
-
-		static System.Text.RegularExpressions.Regex bracketsRegEx = new System.Text.RegularExpressions.Regex(@"\[(?:[^]]+)\]");
-		internal void ExecuteCustombutton(string buttoncode)
-		{
-			buttoncode = buttoncode.Trim();
-			string[] arr = buttoncode.Split(new string[] { Environment.NewLine }, StringSplitOptions.None);
-			foreach (string str in arr)
-			{
-				if (str.Trim().Length > 0)
-				{
-					string tosend = EvaluateExpression(str);
-
-					if (IsImmediate(tosend))
-					{
-						byte b = GetImmediate(tosend);
-						if (b == '!') mHoldByUserRequest = true;
-						SendImmediate(b);
-					}
-					else
-					{ EnqueueCommand(new GrblCommand(tosend)); }
-				}
-			}
-		}
-
-		internal string EvaluateExpression(string str)
-		{
-			return bracketsRegEx.Replace(str, new System.Text.RegularExpressions.MatchEvaluator(EvaluateCB)).Trim();
-		}
-
-		bool IsImmediate(string code)
-		{
-			if (code.ToLower() == "ctrl-x")
-				return true;
-			if (code == "?")
-				return true;
-			if (code == "!")
-				return true;
-			if (code == "~")
-				return true;
-
-			if (code.ToLower().StartsWith("0x"))
-			{
-				try
-				{
-					byte value = Convert.ToByte(code, 16);
-					return true;
-				}
-				catch { return false; }
-			}
-
-			return false;
-		}
-
-		byte GetImmediate(string code)
-		{
-			if (code.ToLower() == "ctrl-x")
-				return 24;
-			if (code == "?")
-				return 63;
-			if (code == "!")
-				return 33;
-			if (code == "~")
-				return 126;
-
-			byte value = Convert.ToByte(code, 16);
-			return value;
-		}
-
-
-		private string EvaluateCB(System.Text.RegularExpressions.Match m)
-		{
-			try
-			{
-				decimal left = LoadedFile != null && LoadedFile.Range.DrawingRange.ValidRange ? LoadedFile.Range.DrawingRange.X.Min : 0;
-				decimal right = LoadedFile != null && LoadedFile.Range.DrawingRange.ValidRange ? LoadedFile.Range.DrawingRange.X.Max : 0;
-				decimal top = LoadedFile != null && LoadedFile.Range.DrawingRange.ValidRange ? LoadedFile.Range.DrawingRange.Y.Max : 0;
-				decimal bottom = LoadedFile != null && LoadedFile.Range.DrawingRange.ValidRange ? LoadedFile.Range.DrawingRange.Y.Min : 0;
-				decimal width = right - left;
-				decimal height = top - bottom;
-				decimal jogstep = JogStep;
-				decimal jogspeed = JogSpeed;
-
-				String text = m.Value.Substring(1, m.Value.Length - 2);
-				Tools.Expression exp = new Tools.Expression(text);
-
-				exp.AddSetVariable("left", (double)left);
-				exp.AddSetVariable("right", (double)right);
-				exp.AddSetVariable("top", (double)top);
-				exp.AddSetVariable("bottom", (double)bottom);
-				exp.AddSetVariable("width", (double)width);
-				exp.AddSetVariable("height", (double)height);
-				exp.AddSetVariable("jogstep", (double)jogstep);
-				exp.AddSetVariable("jogspeed", (double)jogspeed);
-				exp.AddSetVariable("WCO.X", (double)WorkingOffset.X);
-				exp.AddSetVariable("WCO.Y", (double)WorkingOffset.Y);
-				exp.AddSetVariable("WCO.Z", (double)WorkingOffset.Z);
-				exp.AddSetVariable("MPos.X", (double)MachinePosition.X);
-				exp.AddSetVariable("MPos.Y", (double)MachinePosition.Y);
-				exp.AddSetVariable("MPos.Z", (double)MachinePosition.Z);
-				exp.AddSetVariable("WPos.X", (double)MachinePosition.X);
-				exp.AddSetVariable("WPos.Y", (double)MachinePosition.Y);
-				exp.AddSetVariable("WPos.Z", (double)MachinePosition.Z);
-
-				GrblConfST conf = Configuration;
-				if (conf != null)
-				{
-					foreach (KeyValuePair<int, string> p in conf)
-					{
-						if (double.TryParse(p.Value, NumberStyles.Any, CultureInfo.InvariantCulture, out double tod)) //aggiungi solo ciò che si riesce a convertire in double
-							exp.AddSetVariable("$" + p.Key, tod);
-					}
-				}
-
-				double dval = exp.EvaluateD();
-				return m.Result(FormatNumber((decimal)dval));
-			}
-			catch { return m.Value; }
-		}
-
-		static string FormatNumber(decimal value)
-		{ return string.Format(System.Globalization.CultureInfo.InvariantCulture, "{0:0.000}", value); }
-
-
-		public float CurrentF { get { return mCurF; } }
-		public float CurrentS { get { return mCurS; } }
-
-		private static IEnumerable<GrblCommand> StringToGCode(string input)
-		{
-			if (string.IsNullOrEmpty(input))
-				yield break;
-
-			using (System.IO.StringReader reader = new System.IO.StringReader(input))
-			{
-				string line;
-				while (!string.IsNullOrEmpty(line = reader.ReadLine()))
-					yield return new GrblCommand(line);
-			}
-		}
-
-		public virtual bool UIShowGrblConfig => true;
-		public virtual bool UIShowUnlockButtons => true;
-
-		public bool IsOrturBoard { get => GrblVersion != null && GrblVersion.IsOrtur; }
-		public int FailedConnectionCount => mFailedConnection;
-	}
-
-	public class TimeProjection
-	{
-		private TimeSpan mETarget;
-		private TimeSpan mEProgress;
-
-
-		private long mStart;        //Start Time
-		private long mEnd;          //End Time
-		private long mGlobalStart;  //Global Start (multiple pass)
-		private long mGlobalEnd;    //Global End (multiple pass)
-		private long mPauseBegin;   //Pause begin Time
-		private long mCumulatedPause;
-
-		private bool mInPause;
-		private bool mCompleted;
-		private bool mStarted;
-
-		private int mTargetCount;
-		private int mExecutedCount;
-		private int mSentCount;
-		private int mErrorCount;
-		private int mContinueCorrection;
-
-		GrblCore.DetectedIssue mLastIssue;
-		private GPoint mLastKnownWCO;
-
-		public GPoint LastKnownWCO
-		{
-			get { return mLastKnownWCO; }
-			set { if (InProgram) mLastKnownWCO = value; }
-		}
-
-		public TimeProjection()
-		{ Reset(true); }
-
-		public void Reset(bool global)
-		{
-			mETarget = TimeSpan.Zero;
-			mEProgress = TimeSpan.Zero;
-			mStart = mEnd = 0;
-			if (global) mGlobalStart = mGlobalEnd = 0;
-			mPauseBegin = 0;
-			mCumulatedPause = 0;
-			mInPause = false;
-			mCompleted = false;
-			mStarted = false;
-			mExecutedCount = 0;
-			mSentCount = 0;
-			mErrorCount = 0;
-			mTargetCount = 0;
-			mContinueCorrection = 0;
-			mLastIssue = GrblCore.DetectedIssue.Unknown;
-			mLastKnownWCO = GPoint.Zero;
-		}
-
-		public TimeSpan EstimatedTarget
-		{ get { return mETarget; } }
-
-		public bool InProgram
-		{ get { return mStarted && !mCompleted; } }
-
-		public int Target
-		{ get { return mTargetCount; } }
-
-		public int Sent
-		{ get { return mSentCount - mContinueCorrection; } }
-
-		public int Executed
-		{ get { return mExecutedCount - mContinueCorrection; } }
-
-		public TimeSpan ProjectedTarget
-		{
-			get
-			{
-				if (mStarted)
-				{
-					double real = TrueJobTime.TotalSeconds; //job time spent in execution
-					double target = mETarget.TotalSeconds;  //total estimated
-					double done = mEProgress.TotalSeconds;  //done of estimated
-
-					if (done != 0)
-						return TimeSpan.FromSeconds(real * target / done) + TotalJobPauses;
-					else
-						return EstimatedTarget;
-				}
-				else
-					return TimeSpan.Zero;
-			}
-		}
-
-		private TimeSpan TrueJobTime
-		{ get { return TotalJobTime - TotalJobPauses; } }
-
-		public TimeSpan TotalJobTime
-		{
-			get
-			{
-				if (mCompleted)
-					return TimeSpan.FromMilliseconds(mEnd - mStart);
-				else if (mStarted)
-					return TimeSpan.FromMilliseconds(now - mStart);
-				else
-					return TimeSpan.Zero;
-			}
-		}
-
-		public TimeSpan TotalGlobalJobTime
-		{
-			get
-			{
-				if (mCompleted)
-					return TimeSpan.FromMilliseconds(mGlobalEnd - mGlobalStart);
-				else if (mStarted)
-					return TimeSpan.FromMilliseconds(now - mGlobalStart);
-				else
-					return TimeSpan.Zero;
-			}
-		}
-
-		private TimeSpan TotalJobPauses
-		{
-			get
-			{
-				if (mInPause)
-					return TimeSpan.FromMilliseconds(mCumulatedPause + (now - mPauseBegin));
-				else
-					return TimeSpan.FromMilliseconds(mCumulatedPause);
-			}
-		}
-
-		public void JobStart(GrblFile file, Queue<GrblCommand> mQueuePtr, bool global)
-		{
-			if (!mStarted)
-			{
-				mETarget = file.EstimatedTime;
-				mTargetCount = mQueuePtr.Count;
-				mEProgress = TimeSpan.Zero;
-				mStart = Tools.HiResTimer.TotalMilliseconds;
-				if (global) mGlobalStart = mStart;
-				mPauseBegin = 0;
-				mInPause = false;
-				mCompleted = false;
-				mStarted = true;
-				mExecutedCount = 0;
-				mSentCount = 0;
-				mErrorCount = 0;
-				mContinueCorrection = 0;
-				mLastIssue = GrblCore.DetectedIssue.Unknown;
-				mLastKnownWCO = GPoint.Zero;
-			}
-		}
-
-		public void JobContinue(GrblFile file, int position, int added)
-		{
-			if (!mStarted)
-			{
-				if (mETarget == TimeSpan.Zero) mETarget = file.EstimatedTime;
-				if (mTargetCount == 0) mTargetCount = file.Count;
-				//mEProgress = TimeSpan.Zero;
-				if (mStart == 0)
-					mGlobalStart = mStart = Tools.HiResTimer.TotalMilliseconds;
-
-				mPauseBegin = 0;
-				mInPause = false;
-				mCompleted = false;
-				mStarted = true;
-				mExecutedCount = position;
-				mSentCount = position;
-				mLastIssue = GrblCore.DetectedIssue.Unknown;
-				//	mErrorCount = 0;
-				mContinueCorrection = added;
-			}
-		}
-
-		public void JobSent()
-		{
-			if (mStarted && !mCompleted)
-				mSentCount++;
-		}
-
-		public void JobError()
-		{
-			if (mStarted && !mCompleted)
-			{
-				SoundEvent.PlaySound(SoundEvent.EventId.Warning);
-				mErrorCount++;
-			}
-		}
-
-		public void JobExecuted(TimeSpan EstimatedProgress)
-		{
-			if (mStarted && !mCompleted)
-			{
-				mExecutedCount++;
-				mEProgress = EstimatedProgress;
-			}
-		}
-
-		public void JobPause()
-		{
-			if (mStarted && !mCompleted && !mInPause)
-			{
-				mInPause = true;
-				mPauseBegin = now;
-			}
-		}
-
-		public void JobResume()
-		{
-			if (mStarted && !mCompleted && mInPause)
-			{
-				mCumulatedPause += Tools.HiResTimer.TotalMilliseconds - mPauseBegin;
-				mInPause = false;
-			}
-		}
-
-		public bool JobEnd(bool global)
-		{
-			if (mStarted && !mCompleted)
-			{
-				JobResume(); //nel caso l'ultimo comando fosse una pausa, la chiudo e la cumulo
-				mEnd = Tools.HiResTimer.TotalMilliseconds;
-				if (global) mGlobalEnd = mEnd;
-				mCompleted = true;
-				mStarted = false;
-				return true;
-			}
-
-			return false;
-		}
-
-		public void JobIssue(GrblCore.DetectedIssue issue)
-		{ mLastIssue = issue; }
-
-		private long now
-		{ get { return Tools.HiResTimer.TotalMilliseconds; } }
-
-		public int ErrorCount
-		{ get { return mErrorCount; } }
-
-		public GrblCore.DetectedIssue LastIssue
-		{ get { return mLastIssue; } }
-
-
-		//private Tools.ElapsedFromEvent crono = new Tools.ElapsedFromEvent();
-
-		//private string LastJobFileName => System.IO.Path.Combine(GrblCore.DataPath, "lastjob.nc");
-		//private string LastPositionFileName => System.IO.Path.Combine(GrblCore.DataPath, "jobprogress.dat");
-
-		//public void LoadFile(GrblFile file)
-		//{
-		//	try
-		//	{
-		//		if (System.IO.File.Exists(LastJobFileName))
-		//			System.IO.File.Delete(LastJobFileName);
-		//		if (file.Count > 0)
-		//			file.SaveProgram(LastJobFileName, false, false, false, 1);
-		//	}
-		//	catch
-		//	{ }
-		//}
-
-		//public void JobBegin()
-		//{
-		//	try
-		//	{
-		//		if (System.IO.File.Exists(LastPositionFileName))
-		//			System.IO.File.Delete(LastPositionFileName);
-
-		//		crono.Start();
-		//		WriteCurrentPosition();
-		//	}
-		//	catch
-		//	{ }
-		//}
-
-		//public void JobEnd()
-		//{
-		//	//try
-		//	//{
-		//	//	if (System.IO.File.Exists(LastPositionFileName))
-		//	//		System.IO.File.Delete(LastPositionFileName);
-		//	//}
-		//	//catch
-		//	//{ }
-		//}
-
-		//public void JobProgress()
-		//{
-		//	try
-		//	{
-		//		if (crono.ElapsedTime > TimeSpan.FromSeconds(10))
-		//		{
-		//			crono.Start();
-		//			WriteCurrentPosition();
-		//		}
-		//	}
-		//	catch
-		//	{ }
-		//}
-
-		//private void WriteCurrentPosition()
-		//{
-		//	using (System.IO.FileStream fs = new System.IO.FileStream(LastPositionFileName, System.IO.FileMode.Create))
-		//	{
-		//		using (System.IO.BinaryWriter w = new System.IO.BinaryWriter(fs))
-		//		{
-		//			int exec = Executed;
-		//			int sent = Sent;
-		//			int target = Target;
-
-		//			w.Write(exec);
-		//			w.Write(sent);
-		//			w.Write(target);
-		//			w.Write(exec ^ sent ^ target ^ 0x55555555); //checksum valid data
-		//		}
-		//	}
-		//}
-	}
-
-	[Serializable]
-	public class GrblConfST : IEnumerable<KeyValuePair<int, string>>
-	{
-		private const decimal MAX_CONFIG_SPEED = 2000000;
-		private const decimal MAX_CONFIG_PWM = 2000000;
-		private const decimal MAX_CONFIG_RESOLUTION = 10000;
-		private const decimal MAX_CONFIG_SIZE = 2000000;
-		private const decimal MAX_CONFIG_ACCEL = 2000000;
-
-
-		public class GrblConfParam : ICloneable
-		{
-			private int mNumber;
-			private string mValue;
-
-			public GrblConfParam(int number, string value)
-			{ mNumber = number; mValue = value; }
-
-			public int Number
-			{ get { return mNumber; } }
-
-			public string DollarNumber
-			{ get { return "$" + mNumber.ToString(); } }
-
-			public string Parameter
-			{ get { return CSVD.Settings.GetItem(mNumber.ToString(), 0); } }
-
-			//public decimal Value
-			//{
-			//	get { return decimal.Parse(mValue, CultureInfo.InvariantCulture); }
-			//	set { mValue = value.ToString(CultureInfo.InvariantCulture); }
-			//}
-
-			public string Value
-			{
-				get { return mValue; }
-				set { mValue = value; }
-			}
-
-			public string Unit
-			{ get { return CSVD.Settings.GetItem(mNumber.ToString(), 1); } }
-
-			public string Description
-			{ get { return CSVD.Settings.GetItem(mNumber.ToString(), 2); } }
-
-			public object Clone()
-			{ return this.MemberwiseClone(); }
-
-		}
-
-		private Dictionary<int, string> mData;
-		private GrblCore.GrblVersionInfo mVersion;
-
-
-		public GrblConfST()
-		{
-			mData = new Dictionary<int, string>();
-		}
-
-		public GrblConfST(GrblCore.GrblVersionInfo GrblVersion) : this()
-		{
-			mVersion = GrblVersion;
-		}
-
-		public GrblConfST(GrblCore.GrblVersionInfo GrblVersion, Dictionary<int, string> configTable) : this(GrblVersion)
-		{
-			foreach (KeyValuePair<int, string> kvp in configTable)
-				mData.Add(kvp.Key, kvp.Value);
-		}
-
-		public GrblConfST(GrblConf old) : this(old?.GrblVersion)
-		{
-			if (old != null)
-				foreach (KeyValuePair<int, decimal> kvp in old)
-					mData.Add(kvp.Key, kvp.Value.ToString(CultureInfo.InvariantCulture));
-		}
-
-		public GrblCore.GrblVersionInfo GrblVersion => mVersion;
-		private bool NoVersionInfo => mVersion == null;
-		private bool Version11 => mVersion != null && mVersion >= new GrblCore.GrblVersionInfo(1, 1);
-		private bool Version9 => mVersion != null && mVersion >= new GrblCore.GrblVersionInfo(0, 9);
-
-		public int ExpectedCount => Version11 ? 34 : Version9 ? 31 : 23;
-		public bool HomingEnabled => ReadDecimal(Version9 ? 22 : 17, 1, 0, 1) != 0;
-		public decimal MaxRateX => ReadDecimal(Version9 ? 110 : 4, 4000, 1, MAX_CONFIG_SPEED);
-		public decimal MaxRateY => ReadDecimal(Version9 ? 111 : 5, 4000, 1, MAX_CONFIG_SPEED);
-
-		public bool LaserMode
-		{
-			get
-			{
-				if (NoVersionInfo)
-					return true;
-				else
-					return ReadDecimal(Version11 ? 32 : -1, 0, 0, 1) != 0;
-			}
-		}
-
-		public decimal MinPWM => ReadDecimal(Version11 ? 31 : -1, 0, 0, MAX_CONFIG_PWM);
-		public decimal MaxPWM => ReadDecimal(Version11 ? 30 : -1, 1000, 1, MAX_CONFIG_PWM);
-		public decimal ResolutionX => ReadDecimal(Version9 ? 100 : 0, 250, 1, MAX_CONFIG_RESOLUTION);
-		public decimal ResolutionY => ReadDecimal(Version9 ? 101 : 1, 250, 1, MAX_CONFIG_RESOLUTION);
-		public decimal TableWidth => ReadDecimal(Version9 ? 130 : -1, 300, 1, MAX_CONFIG_SIZE);
-		public decimal TableHeight => ReadDecimal(Version9 ? 131 : -1, 200, 1, MAX_CONFIG_SIZE);
-		public bool SoftLimit => ReadDecimal(20, 0, 0, 1) != 0;
-
-		public decimal AccelerationXY => (AccelerationX + AccelerationY) / 2;
-		private decimal AccelerationX => ReadDecimal(Version9 ? 120 : -1, 2000, 1, MAX_CONFIG_ACCEL);
-		private decimal AccelerationY => ReadDecimal(Version9 ? 121 : -1, 2000, 1, MAX_CONFIG_ACCEL);
-
-		public string WiFi_SSID => ReadString(74, null);
-		public string WiFi_Pwd => ReadString(75, null);
-		public string TelnetPort => ReadString(305, "23");
-
-
-		private decimal ReadDecimal(int key, decimal defval, decimal min, decimal max)
-		{
-			if (mVersion == null)
-				return defval;
-			else if (!mData.ContainsKey(key))
-				return defval;
-			else
-			{
-				try
-				{
-					return Math.Max(min, Math.Min(max, decimal.Parse(mData[key], CultureInfo.InvariantCulture)));
-				}
-				catch
-				{
-					try //proviamo a pulire la stringa con una regex?!
-					{
-						System.Text.RegularExpressions.Regex ExtractNumber = new System.Text.RegularExpressions.Regex(@"(\d+\.?\d*)");
-						System.Text.RegularExpressions.MatchCollection matches = ExtractNumber.Matches(mData[key]);
-						return decimal.Parse(matches[0].Groups[1].Value);
-					}
-					catch
-					{
-						return defval;
-					}
-				}
-			}
-		}
-
-		private string ReadString(int number, string defval)
-		{
-			if (mVersion == null)
-				return defval;
-			else if (!mData.ContainsKey(number))
-				return defval;
-			else
-				return mData[number];
-		}
-
-		public List<GrblConfParam> ToList()
-		{
-			List<GrblConfParam> rv = new List<GrblConfParam>();
-			foreach (KeyValuePair<int, string> kvp in mData)
-				rv.Add(new GrblConfParam(kvp.Key, kvp.Value));
-			return rv;
-		}
-
-		public int Count { get { return mData.Count; } }
-
-
-
-		internal bool HasChanges(GrblConfParam p)
-		{
-			if (!mData.ContainsKey(p.Number))
-				return true;
-			else if (mData[p.Number] != p.Value)
-				return true;
-			else
-				return false;
-		}
-
-		private bool ContainsKey(int key)
-		{
-			return mData.ContainsKey(key);
-		}
-
-
-		public IEnumerator<KeyValuePair<int, string>> GetEnumerator()
-		{
-			return mData.GetEnumerator();
-		}
-
-		System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator()
-		{
-			return mData.GetEnumerator();
-		}
-
-		// "$" at the beginning of a line, followed by numbers, by any spaces, by "=" and then averything
-		private static System.Text.RegularExpressions.Regex ConfRegEX = new System.Text.RegularExpressions.Regex(@"^[$](\d+)\s*=(.*)");
-
-		public static bool IsSetConf(string p)
-		{ return ConfRegEX.IsMatch(p); }
-
-		public void AddOrUpdate(string line)
-		{
-			try
-			{
-				if (IsSetConf(line))
-				{
-					line = FixFoxalienConfig(line);
-
-					System.Text.RegularExpressions.MatchCollection matches = ConfRegEX.Matches(line);
-					int key = int.Parse(matches[0].Groups[1].Value);
-					string val = matches[0].Groups[2].Value.Trim();
-
-					if (ContainsKey(key))
-						mData[key] = val;
-					else
-						mData.Add(key, val);
-				}
-			}
-			catch (Exception)
-			{
-
-			}
-		}
-
-
-		// Foxalien send config values with descriprion inside it i.e. "$20=0 (soft limits, bool)\r" , so we need to do a cleanup to remove description between parentesis
-		// See issue https://github.com/arkypita/LaserGRBL/issues/1890
-		private static System.Text.RegularExpressions.Regex FoxalienCleanupConfig = new System.Text.RegularExpressions.Regex(@"^[$](\d+)\s*=\s*(\d+\.?\d*)\s*\(.*\)");
-		private string FixFoxalienConfig(string line)
-		{
-			if (!FoxalienCleanupConfig.IsMatch(line))
-				return line;
-
-			System.Text.RegularExpressions.MatchCollection matches = FoxalienCleanupConfig.Matches(line);
-			int key = int.Parse(matches[0].Groups[1].Value);
-			string val = matches[0].Groups[2].Value.Trim();
-
-			return $"${key}={val}";
-		}
-
-		internal bool SetValueIfKeyExist(string p)
-		{
-			try
-			{
-				if (IsSetConf(p))
-				{
-					System.Text.RegularExpressions.MatchCollection matches = ConfRegEX.Matches(p);
-					int key = int.Parse(matches[0].Groups[1].Value);
-					string val = matches[0].Groups[2].Value.Trim();
-
-					if (!ContainsKey(key))
-						return false;
-
-					mData[key] = val;
-					return true;
-				}
-			}
-			catch (Exception)
-			{
-
-			}
-
-			return false;
-		}
-
-		internal string ValidateConfig(int parid, object value)
-		{
-			if (parid == 33 && mVersion != null && mVersion.IsOrtur)
-				return "This param control an Ortur safety feature. Please do not change this value!";
-
-			return null;
-		}
-	}
-
-
-
-	[Serializable, Obsolete]
-	public class GrblConf : IEnumerable<KeyValuePair<int, decimal>>
-	{
-		[Obsolete]
-		public class GrblConfParam : ICloneable
-		{
-			private int mNumber;
-			private decimal mValue;
-
-			public GrblConfParam(int number, decimal value)
-			{ mNumber = number; mValue = value; }
-
-			public int Number
-			{ get { return mNumber; } }
-
-			public string DollarNumber
-			{ get { return "$" + mNumber.ToString(); } }
-
-			public string Parameter
-			{ get { return CSVD.Settings.GetItem(mNumber.ToString(), 0); } }
-
-			public decimal Value
-			{
-				get { return mValue; }
-				set { mValue = value; }
-			}
-
-			public string Unit
-			{ get { return CSVD.Settings.GetItem(mNumber.ToString(), 1); } }
-
-			public string Description
-			{ get { return CSVD.Settings.GetItem(mNumber.ToString(), 2); } }
-
-			public object Clone()
-			{ return this.MemberwiseClone(); }
-
-		}
-
-		private System.Collections.Generic.Dictionary<int, decimal> mData;
-		private GrblCore.GrblVersionInfo mVersion;
-
-		public GrblConf(GrblCore.GrblVersionInfo GrblVersion)
-			: this()
-		{
-			mVersion = GrblVersion;
-		}
-
-		public GrblConf(GrblCore.GrblVersionInfo GrblVersion, System.Collections.Generic.Dictionary<int, decimal> configTable)
-			: this(GrblVersion)
-		{
-			foreach (System.Collections.Generic.KeyValuePair<int, decimal> kvp in configTable)
-				mData.Add(kvp.Key, kvp.Value);
-		}
-
-		public GrblConf()
-		{ mData = new System.Collections.Generic.Dictionary<int, decimal>(); }
-
-		public GrblCore.GrblVersionInfo GrblVersion => mVersion;
-		private bool NoVersionInfo => mVersion == null;
-		private bool Version11 => mVersion != null && mVersion >= new GrblCore.GrblVersionInfo(1, 1);
-		private bool Version9 => mVersion != null && mVersion >= new GrblCore.GrblVersionInfo(0, 9);
-
-		public int ExpectedCount => Version11 ? 34 : Version9 ? 31 : 23;
-		public bool HomingEnabled => ReadWithDefault(Version9 ? 22 : 17, 1) != 0;
-		public decimal MaxRateX => ReadWithDefault(Version9 ? 110 : 4, 4000);
-		public decimal MaxRateY => ReadWithDefault(Version9 ? 111 : 5, 4000);
-
-		public bool LaserMode
-		{
-			get
-			{
-				if (NoVersionInfo)
-					return true;
-				else
-					return ReadWithDefault(Version11 ? 32 : -1, 0) != 0;
-			}
-		}
-
-		public decimal MinPWM => ReadWithDefault(Version11 ? 31 : -1, 0);
-		public decimal MaxPWM => ReadWithDefault(Version11 ? 30 : -1, 1000);
-		public decimal ResolutionX => ReadWithDefault(Version9 ? 100 : 0, 250);
-		public decimal ResolutionY => ReadWithDefault(Version9 ? 101 : 1, 250);
-		public decimal TableWidth => ReadWithDefault(Version9 ? 130 : -1, 300);
-		public decimal TableHeight => ReadWithDefault(Version9 ? 131 : -1, 200);
-		public bool SoftLimit => ReadWithDefault(20, 0) != 0;
-
-		public decimal AccelerationXY => (AccelerationX + AccelerationY) / 2;
-		private decimal AccelerationX => ReadWithDefault(Version9 ? 120 : -1, 2000);
-		private decimal AccelerationY => ReadWithDefault(Version9 ? 121 : -1, 2000);
-
-		private decimal ReadWithDefault(int number, decimal defval)
-		{
-			if (mVersion == null)
-				return defval;
-			else if (!mData.ContainsKey(number))
-				return defval;
-			else
-				return mData[number];
-		}
-
-		//public object Clone()
-		//{
-		//	GrblConf rv = new GrblConf();
-		//	rv.mVersion = mVersion != null ? mVersion.Clone() as GrblCore.GrblVersionInfo : null;
-		//	foreach (System.Collections.Generic.KeyValuePair<int, GrblConf.GrblConfParam> kvp in this)
-		//		rv.Add(kvp.Key, kvp.Value.Clone() as GrblConfParam);
-		//	return rv;
-		//}
-
-		public System.Collections.Generic.List<GrblConf.GrblConfParam> ToList()
-		{
-			System.Collections.Generic.List<GrblConfParam> rv = new System.Collections.Generic.List<GrblConfParam>();
-			foreach (System.Collections.Generic.KeyValuePair<int, decimal> kvp in mData)
-				rv.Add(new GrblConfParam(kvp.Key, kvp.Value));
-			return rv;
-		}
-
-		private void Add(int num, decimal val)
-		{
-			mData.Add(num, val);
-		}
-
-		public int Count { get { return mData.Count; } }
-
-		internal bool HasChanges(GrblConfParam p)
-		{
-			if (!mData.ContainsKey(p.Number))
-				return true;
-			else if (mData[p.Number] != p.Value)
-				return true;
-			else
-				return false;
-		}
-
-		private bool ContainsKey(int key)
-		{
-			return mData.ContainsKey(key);
-		}
-
-		private void SetValue(int key, decimal value)
-		{
-			mData[key] = value;
-		}
-
-		public System.Collections.Generic.IEnumerator<System.Collections.Generic.KeyValuePair<int, decimal>> GetEnumerator()
-		{
-			return mData.GetEnumerator();
-		}
-
-		System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator()
-		{
-			return mData.GetEnumerator();
-		}
-
-
-		private static System.Text.RegularExpressions.Regex ConfRegEX = new System.Text.RegularExpressions.Regex(@"^[$](\d+) *= *(\d+\.?\d*)");
-
-		public static bool IsSetConf(string p)
-		{ return ConfRegEX.IsMatch(p); }
-
-		public void AddOrUpdate(string p)
-		{
-			try
-			{
-				if (IsSetConf(p))
-				{
-					System.Text.RegularExpressions.MatchCollection matches = ConfRegEX.Matches(p);
-					int key = int.Parse(matches[0].Groups[1].Value);
-					decimal val = decimal.Parse(matches[0].Groups[2].Value, System.Globalization.CultureInfo.InvariantCulture);
-
-					if (ContainsKey(key))
-						SetValue(key, val);
-					else
-						Add(key, val);
-				}
-			}
-			catch (Exception)
-			{
-
-			}
-		}
-
-		internal bool SetValueIfKeyExist(string p)
-		{
-			try
-			{
-				if (IsSetConf(p))
-				{
-					System.Text.RegularExpressions.MatchCollection matches = ConfRegEX.Matches(p);
-					int key = int.Parse(matches[0].Groups[1].Value);
-					decimal val = decimal.Parse(matches[0].Groups[2].Value, System.Globalization.CultureInfo.InvariantCulture);
-
-					if (!ContainsKey(key))
-						return false;
-
-					SetValue(key, val);
-					return true;
-				}
-			}
-			catch (Exception)
-			{
-
-			}
-
-			return false;
-		}
-
-		internal string ValidateConfig(int parid, object value)
-		{
-			if (parid == 33 && mVersion != null && mVersion.IsOrtur)
-				return "This param control an Ortur safety feature. Please do not change this value!";
-
-			return null;
-		}
-	}
-
-	public struct GPoint
-	{
-		public float X, Y, Z;
-
-		public GPoint(float x, float y, float z)
-		{
-			X = x;
-			Y = y;
-			Z = z;
-		}
-
-		public static GPoint Zero { get { return new GPoint(); } }
-
-		public static bool operator ==(GPoint a, GPoint b)
-		{ return a.X == b.X && a.Y == b.Y && a.Z == b.Z; }
-
-		public static bool operator !=(GPoint a, GPoint b)
-		{ return !(a == b); }
-
-		public static GPoint operator -(GPoint a, GPoint b)
-		{ return new GPoint(a.X - b.X, a.Y - b.Y, a.Z - b.Z); }
-
-		public static GPoint operator +(GPoint a, GPoint b)
-		{ return new GPoint(a.X + b.X, a.Y + b.Y, a.Z + b.Z); }
-
-		public override bool Equals(object obj)
-		{
-			return obj is GPoint && ((GPoint)obj) == this;
-		}
-
-		public override int GetHashCode()
-		{
-			unchecked // Overflow is fine, just wrap
-			{
-				int hash = 17;
-				hash = hash * 23 + X.GetHashCode();
-				hash = hash * 23 + Y.GetHashCode();
-				hash = hash * 23 + Z.GetHashCode();
-				return hash;
-			}
-		}
-
-		internal PointF ToPointF()
-		{
-			return new PointF(X, Y);
-		}
-	}
-
-
-	public static class LaserLifeHandler
-	{
-		[Serializable]
-		public class ListLLC : List<LaserLifeCounter>
-		{
-			public DateTime LastAttempt = new DateTime(2000, 1, 1);
-			public DateTime LastSent = new DateTime(2000, 1, 1);
-
-			internal ListLLC GetClone()
-			{
-				ListLLC clone = new ListLLC();
-
-				lock (this)
-				{
-					foreach (LaserLifeCounter LLC in this)
-						clone.Add(LLC.Clone());
-					clone.LastSent = LastSent;
-					clone.LastAttempt = LastAttempt;
-				}
-
-				return clone;
-			}
-
-			//internal void FixWeirdMeasures()
-			//{
-			//	foreach (LaserLifeCounter LLC in this)
-			//		LLC.FixWeirdMeasures();
-			//}
-		}
-
-		static ListLLC mLLCL;
-		static LaserLifeCounter mCurrentLLC;
-		private static long? mLastStatusHiResTimeNano;
-		private static long? mLastPowerHiResTimeNano;
-		private static long mLastSave;
-		private static string mLLCFileName;
-
-		[Serializable]
-		public class LaserLifeCounter : IDeserializationCallback
-		{
-			public static string DEF_NAME = "Default";
-			public static string DEF_BRAND = "Unknown";
-			public static string DEF_MODEL = "Unknown";
-			private string mGuid;
-
-			private string mName;
-			private string mBrand;
-			private string mModuleModel;
-			private double? mOpticalPower;
-
-			private DateTime? mPurchaseDate;
-			private DateTime? mMonitoringDate;
-			private DateTime? mDeathDate;
-			private DateTime? mLastUsage;
-
-			private TimeSpan mTimeInRun;
-			private TimeSpan mTimeUsageNormalizedPower;
-			private TimeSpan mTimeUsageNonZero;
-			private TimeSpan[] mTimeClasses;
-
-			public DateTime? PurchaseDate { get => mPurchaseDate; set => mPurchaseDate = value; }
-			public DateTime? MonitoringDate { get => mMonitoringDate; set => mMonitoringDate = value; }
-			public DateTime? DeathDate { get => mDeathDate; set => mDeathDate = value; }
-			public DateTime? LastUsage { get => mLastUsage; set => mLastUsage = value; }
-			public string Name { get => mName; set => mName = value; }
-			public string Brand { get => mBrand; set => mBrand = value; }
-			public string Model { get => mModuleModel; set => mModuleModel = value; }
-			public double? OpticalPower { get => mOpticalPower; set => mOpticalPower = value; }
-			public TimeSpan TimeInRun { get => mTimeInRun; }
-			public TimeSpan TimeUsageNormalizedPower { get => mTimeUsageNormalizedPower; }
-			public TimeSpan StressTime { get => mTimeClasses[9]; }
-			public double AveragePowerFactor { get => mTimeUsageNonZero.TotalSeconds == 0 ? 0 : mTimeUsageNormalizedPower.TotalSeconds / mTimeUsageNonZero.TotalSeconds; }
-			public string Guid { get => mGuid; }
-			public TimeSpan[] Classes { get => mTimeClasses; }
-
-			private LaserLifeCounter()
-			{
-				mGuid = System.Guid.NewGuid().ToString();
-				mMonitoringDate = DateTime.Today;
-				mTimeClasses = new TimeSpan[10];
-			}
-
-			internal static LaserLifeCounter CreateNew()
-			{
-				LaserLifeCounter rv = new LaserLifeCounter();
-				return rv;
-			}
-			public static LaserLifeCounter CreateDefault()
-			{
-				LaserLifeCounter rv = new LaserLifeCounter();
-				rv.Name = DEF_NAME;
-				return rv;
-			}
-
-			internal void AddRunTime(TimeSpan elapsed)
-			{
-				//elapsed = TimeSpan.FromSeconds(elapsed.TotalSeconds * 100);
-				mTimeInRun = mTimeInRun.Add(elapsed);
-				mLastUsage = DateTime.Today;
-			}
-
-			internal LaserLifeCounter Clone()
-			{
-				return MemberwiseClone() as LaserLifeCounter;
-			}
-
-			internal void AddTrueLaserTimePower(TimeSpan elapsed, double powerperc)
-			{
-				//elapsed = TimeSpan.FromSeconds(elapsed.TotalSeconds * 100);
-
-				if (powerperc > 0.03) //do not track any usage under 3% (framing etc)
-				{
-					TimeSpan normalized = TimeSpan.FromMilliseconds(elapsed.TotalMilliseconds * powerperc); //normalize elapsed time with power
-					mTimeUsageNormalizedPower = mTimeUsageNormalizedPower + normalized;
-					mTimeUsageNonZero = mTimeUsageNonZero + elapsed;
-				}
-
-				if (powerperc > 0.01)
-				{
-					int clx = (int)Math.Floor((powerperc * 100 - 1) / 10); //1-10 = 0, 11-20 = 1; 91-100 = 9
-					clx = Math.Min(9, Math.Max(0, clx)); //ensure 0-9 range
-					mTimeClasses[clx] = mTimeClasses[clx] + elapsed;
-				}
-				mLastUsage = DateTime.Today;
-				//System.Diagnostics.Debug.WriteLine($"LT: {mTimeInRun.TotalSeconds} LTT: {mTimeUsageNormalizedPower.TotalSeconds}");
-			}
-
-			internal void Update(LaserLifeCounter selected)
-			{
-				mName = selected.mName;
-				mPurchaseDate = selected.mPurchaseDate;
-				mDeathDate = selected.mDeathDate;
-				mModuleModel = selected.mModuleModel;
-				mBrand = selected.mBrand;
-				mOpticalPower = selected.mOpticalPower;
-			}
-
-			internal bool HasWorked()
-			{
-				return mTimeInRun.TotalHours > 1;
-			}
-
-			void IDeserializationCallback.OnDeserialization(object sender)
-			{
-				if (mTimeClasses == null)
-					mTimeClasses = new TimeSpan[10];
-			}
-
-			//internal void FixWeirdMeasures()
-			//{
-			//	TimeSpan TT = TimeSpan.Zero;
-			//	foreach (TimeSpan TS in Classes)
-			//		TT = TT.Add(TS);
-
-			//	if (
-			//		LastUsage.HasValue &&
-			//		DateTime.Today < new DateTime(2023, 12, 31) && // smette di farlo ad una certa data
-			//		TimeInRun.TotalHours > 100 && // almeno 100 ore
-			//		TimeInRun.TotalHours > ((LastUsage.Value - MonitoringDate.Value).TotalHours + 24) * 2 && //TIR > 2 * DELTA TRA DATE MONITORATE
-			//		TimeInRun.TotalHours > TT.TotalHours * 100 //TIR > 100 volte Classes.Time
-			//		)
-			//		mTimeInRun = TimeSpan.FromHours(TT.TotalHours * 1.5); //ri-assegna da TT (total time preso dalle classi) esteso * 1.5
-			//}
-		}
-
-		static LaserLifeHandler()
-		{
-			if (mLLCL == null)
-			{
-				mLLCFileName = System.IO.Path.Combine(GrblCore.DataPath, "LaserLifeCounter.bin");
-				mLLCL = Serializer.ObjFromFile(mLLCFileName) as ListLLC;
-				if (mLLCL == null) mLLCL = Serializer.ObjFromFile(mLLCFileName + ".old") as ListLLC;
-
-				if (mLLCL == null) mLLCL = new ListLLC();
-				if (mLLCL.Count == 0) mLLCL.Add(LaserLifeCounter.CreateDefault());
-
-				//mLLCL.FixWeirdMeasures();
-			}
-		}
-
-		public static void ComputeLaserTime(GrblCore.MacStatus status)
-		{
-			try
-			{
-				lock (mLLCL)
-				{
-					long now = HiResTimer.TotalNano;
-					if (mLastStatusHiResTimeNano != null)
-					{
-						long delta = now - mLastPowerHiResTimeNano.Value;
-						if (delta > 0 && delta < 600000000000L) //do not add delta if bigger then 600s (or negative) - just a safety test
-						{ 
-							double perc = status == MacStatus.Run ? 1 : 0; //potenza da applicare a questo delta
-							double normal = delta * perc;
-							mCurrentLLC?.AddRunTime(TimeSpan.FromMilliseconds(normal / 1000 / 1000));
-						}
-					}
-					mLastStatusHiResTimeNano = now;
-				}
-				SendAndSave();
-			}
-			catch { }
-		}
-
-		private static void SendAndSave()
-		{
-			DoSend();
-			DoSave();
-		}
-
-		public static void ComputeLaserTrueTime(float power)
-		{
-			try
-			{
-				lock (mLLCL)
-				{
-					long now = HiResTimer.TotalNano;
-					if (mLastPowerHiResTimeNano != null)
-					{
-						long delta = now - mLastPowerHiResTimeNano.Value;
-						if (delta > 0 && delta < 600000000000L) //do not add delta if bigger then 600s (or negative) - just a safety test
-						{ 
-							decimal maxpwm = Configuration.MaxPWM;
-
-							if (maxpwm >= 10 && maxpwm <= 100000) //we have a configured value in a valid range
-							{
-								double powerperc = Math.Max(0, Math.Min(1, (double)power / (double)maxpwm)); //potenza da applicare a questo delta
-								mCurrentLLC?.AddTrueLaserTimePower(TimeSpan.FromMilliseconds((double)delta / 1000000.0), powerperc);
-							}
-						}
-					}
-					mLastPowerHiResTimeNano = now;
-				}
-				SendAndSave();
-			}
-			catch { }
-		}
-
-		public static void OnConnect(Form parent)
-		{
-			try
-			{
-				List<LaserLifeCounter> alive = mLLCL.Where(l => !l.DeathDate.HasValue).ToList();
-				List<LaserLifeCounter> death = mLLCL.Where(l => !l.DeathDate.HasValue).ToList();
-
-				if (mLLCL.Count == 0)           //non ce ne sono... non tracciamo
-					mCurrentLLC = null;
-				if (mLLCL.Count == 1)           //se ne abbiamo uno solo è per forza lui, vivo o morto che sia
-					mCurrentLLC = mLLCL[0];
-				else if (alive.Count == 1)      //se ne abbiamo più di uno, ma uno solo è vivo => è per forza lui 
-					mCurrentLLC = alive[0];
-				else
-				{
-					string selguid = LaserSelector.CreateAndShowDialog(parent);
-					mCurrentLLC = mLLCL.First(l => l.Guid == selguid);
-				}
-			}
-			catch { mCurrentLLC = null; }
-
-			Settings.SetObject("Last laser used", mCurrentLLC != null ? mCurrentLLC.Guid : null);
-		}
-
-		internal static void OnDisconnect()
-		{
-			mCurrentLLC = null;
-		}
-
-		private static void DoSave()
-		{
-			try
-			{
-				lock(mLLCFileName)
-				{ 
-					long now = HiResTimer.TotalMilliseconds;
-					if (mLastSave == 0 || now - mLastSave > 20000) //save every 20s
-					{
-						ListLLC tosave = GetListClone();
-						System.Threading.ThreadPool.QueueUserWorkItem(new System.Threading.WaitCallback(RealDoSave), tosave);
-						mLastSave = now;
-					}
-				}
-			}
-			catch { }
-		}
-
-		private static void DoSend()
-		{
-			try
-			{
-				DateTime now = DateTime.Now;
-				bool sendnow = false;
-				lock (mLLCL)
-				{
-					if ((now - mLLCL.LastSent).TotalDays > 14 && (now - mLLCL.LastAttempt).TotalDays > 1)
-					{
-						mLLCL.LastAttempt = now;
-						sendnow = true;
-					}
-				}
-
-				if (sendnow)
-				{
-					ListLLC tosend = GetListClone();
-					System.Threading.ThreadPool.QueueUserWorkItem(new System.Threading.WaitCallback(RealDoSend), tosend);
-				}
-			}
-			catch { }
-		}
-
-		public static ListLLC GetListClone()
-		{
-			return mLLCL?.GetClone();
-		}
-
-		public static void SaveNow()
-		{
-			try { RealDoSave(GetListClone()); }
-			catch { }
-		}
-
-		private static void RealDoSend(object state)
-		{
-			try
-			{
-				List<LaserLifeCounter> tosave = (state as ListLLC).Where(t => t.HasWorked()).ToList();
-				if (UrlManager.LaserStatistics != null && tosave.Count > 0)
-				{
-					string urlAddress = UrlManager.LaserStatistics;
-					using (UsageStats.MyWebClient client = new UsageStats.MyWebClient())
-					{
-						System.Collections.Specialized.NameValueCollection postData = new System.Collections.Specialized.NameValueCollection()
-						{
-							{ "version" , "2" },
-							{ "guid", UsageStats.GetID() },
-							{ "data", BuildJson(tosave) },
-						};
-
-						// client.UploadValues returns page's source as byte array (byte[]) so it must be transformed into a string
-						string json = System.Text.Encoding.UTF8.GetString(client.UploadValues(urlAddress, postData));
-
-						//RealDoSendRV RV = Tools.JSONParser.FromJson<RealDoSendRV>(json);
-						if (json == "Success!")
-							mLLCL.LastSent = DateTime.Now;
-					}
-				}
-
-			}
-			catch { }
-		}
-
-		private static string BuildJson(List<LaserLifeCounter> tosend)
-		{
-			//return "[ { \"id\": \"5001\", \"type\": \"None\" }, { \"id\": \"5004\", \"type\": \"Maple\" } ]";
-
-			System.Text.StringBuilder sb = new System.Text.StringBuilder();
-			sb.Append("[ ");
-
-
-
-			for (int i = 0; i < tosend.Count; i++)
-			{
-				LaserLifeCounter LLC = tosend[i];
-
-				sb.Append("{ ");
-
-				sb.Append($"\"Guid\": {EscapeJson(LLC.Guid)},");
-				sb.Append($"\"Name\": {EscapeJson(LLC.Name)},");
-				sb.Append($"\"Brand\": {EscapeJson(LLC.Brand)},");
-				sb.Append($"\"Model\": {EscapeJson(LLC.Model)},");
-				sb.Append($"\"OpticalPower\": {EscapeJson(LLC.OpticalPower)},");
-				sb.Append($"\"PurchaseDate\": {EscapeJson(LLC.PurchaseDate?.ToString("yyyy-MM-dd HH:mm:ss"))},");
-				sb.Append($"\"MonitoringDate\": {EscapeJson(LLC.MonitoringDate?.ToString("yyyy-MM-dd HH:mm:ss"))},");
-				sb.Append($"\"DeathDate\": {EscapeJson(LLC.DeathDate?.ToString("yyyy-MM-dd HH:mm:ss"))},");
-				sb.Append($"\"LastUsage\": {EscapeJson(LLC.LastUsage?.ToString("yyyy-MM-dd HH:mm:ss"))},");
-				sb.Append($"\"TimeInRun\": {EscapeJson(LLC.TimeInRun.TotalHours)},");
-				sb.Append($"\"TimeUsageNormalizedPower\": {EscapeJson(LLC.TimeUsageNormalizedPower.TotalHours)},");
-				sb.Append($"\"AveragePowerFactor\": {EscapeJson(LLC.AveragePowerFactor)},");
-
-				sb.Append($"\"Classes\": ");
-				{
-					sb.Append("{ ");
-
-					for (int j = 0; j < LLC.Classes.Length; j++)
-					{
-						sb.Append($"{LLC.Classes[j].TotalHours.ToString("0.000", NumberFormatInfo.InvariantInfo)}");
-
-						if (j == LLC.Classes.Length - 1) //ultimo
-							sb.Append(" } ");
-						else
-							sb.Append(", ");
-
-					}
-				}
-
-				if (i == tosend.Count - 1) //ultimo
-					sb.Append(" } ");
-				else
-					sb.Append(" }, ");
-			}
-
-			sb.Append(" ]");
-			return sb.ToString();
-		}
-
-		static string EscapeJson(object o)
-		{
-			if (o is double?)
-				return $"\"{(o as double?).GetValueOrDefault().ToString("0.000", NumberFormatInfo.InvariantInfo)}\"";
-			else if (o is double)
-				return $"\"{((double)o).ToString("0.000", NumberFormatInfo.InvariantInfo)}\"";
-			else
-				return HttpUtility.JavaScriptStringEncode(o != null ? o.ToString() : "", true);
-		}
-
-		public class RealDoSendRV
-		{
-			public int UpdateResult = -1;
-
-			[IgnoreDataMember] public bool Success => UpdateResult == 1;
-		}
-
-		private static void RealDoSave(object state)
-		{
-			try
-			{
-				lock (mLLCFileName)
-				{
-					ListLLC tosave = state as ListLLC;
-					if (tosave != null)
-					{
-						try
-						{
-							if (System.IO.File.Exists(mLLCFileName))
-							{
-								if (System.IO.File.Exists(mLLCFileName + ".old"))
-									System.IO.File.Delete(mLLCFileName + ".old");
-								System.IO.File.Move(mLLCFileName, mLLCFileName + ".old");
-							}
-						}
-						catch { }
-
-						try
-						{
-							if (System.IO.File.Exists(mLLCFileName))
-								System.IO.File.Delete(mLLCFileName);
-						}
-						catch { }
-
-						Serializer.ObjToFile(tosave, mLLCFileName);
-					}
-				}
-			}
-			catch { }
-		}
-
-		internal static TimeSpan GetCurrentTime()
-		{
-			return mCurrentLLC != null ? mCurrentLLC.TimeInRun : TimeSpan.Zero;
-		}
-
-		internal static void Add(LaserLifeCounter llc)
-		{
-			lock (mLLCL)
-			{
-				mLLCL.Add(llc);
-				SaveNow();
-			}
-		}
-
-		internal static void Edit(LaserLifeCounter selected)
-		{
-			lock (mLLCL)
-			{
-				foreach (LaserLifeCounter llc in mLLCL)
-				{
-					if (llc.Guid == selected.Guid)
-						llc.Update(selected);
-				}
-				SaveNow();
-			}
-		}
-
-		internal static string Delete(LaserLifeCounter selected)
-		{
-			lock (mLLCL)
-			{
-				if (mCurrentLLC != null && selected.Guid == mCurrentLLC.Guid)
-					return "You cannot delete currently connected Laser module!";
-
-				mLLCL.RemoveAll(l => l.Guid == selected.Guid);
-				SaveNow();
-				return null;
-			}
-		}
-
-		internal static void Death(LaserLifeCounter selected)
-		{
-			lock (mLLCL)
-			{
-				foreach (LaserLifeCounter llc in mLLCL)
-				{
-					if (llc.Guid == selected.Guid && llc.DeathDate == null)
-						llc.DeathDate = DateTime.Today;
-				}
-				SaveNow();
-			}
-		}
-
-		internal static void UnDeath(LaserLifeCounter selected)
-		{
-			lock (mLLCL)
-			{
-				foreach (LaserLifeCounter llc in mLLCL)
-				{
-					if (llc.Guid == selected.Guid && llc.DeathDate != null)
-						llc.DeathDate = null;
-				}
-				SaveNow();
-			}
-		}
-	}
+    public enum Firmware
+    { Grbl, Smoothie, Marlin, VigoWork }
+
+    /// <summary>
+    /// Description of CommandThread.
+    /// </summary>
+    public class GrblCore
+    {
+        //public static PSHelper.PSFile MaterialDB = PSHelper.PSFile.Load();
+        public static PSHelper.MaterialDB MaterialDB = PSHelper.MaterialDB.Load();
+
+        public static string GCODE_STD_HEADER = "G90 (use absolute coordinates)";
+        public static string GCODE_STD_PASSES = ";(Uncomment if you want to sink Z axis)\r\n;G91 (use relative coordinates)\r\n;G0 Z-1 (sinks the Z axis, 1mm)\r\n;G90 (use absolute coordinates)";
+        public static string GCODE_STD_FOOTER = "G0 X0 Y0 Z0 (move back to origin)";
+
+        [Serializable]
+        public class ThreadingMode
+        {
+            public readonly int StatusQuery;
+            public readonly int TxLong;
+            public readonly int TxShort;
+            public readonly int RxLong;
+            public readonly int RxShort;
+            private readonly string Name;
+
+            public ThreadingMode(int query, int txlong, int txshort, int rxlong, int rxshort, string name)
+            { StatusQuery = query; TxLong = txlong; TxShort = txshort; RxLong = rxlong; RxShort = rxshort; Name = name; }
+
+            public static ThreadingMode Slow
+            { get { return new ThreadingMode(2000, 15, 4, 2, 1, "Slow"); } }
+
+            public static ThreadingMode Quiet
+            { get { return new ThreadingMode(1000, 10, 2, 1, 1, "Quiet"); } }
+
+            public static ThreadingMode Fast
+            { get { return new ThreadingMode(500, 5, 1, 1, 0, "Fast"); } }
+
+            public static ThreadingMode UltraFast
+            { get { return new ThreadingMode(250, 1, 0, 0, 0, "UltraFast"); } }
+
+            public static ThreadingMode Insane
+            { get { return new ThreadingMode(200, 1, 0, 0, 0, "Insane"); } }
+
+            public override string ToString()
+            { return Name; }
+
+            public override bool Equals(object obj)
+            { return obj != null && obj is ThreadingMode && ((ThreadingMode)obj).Name == Name; }
+
+            public override int GetHashCode()
+            {
+                return base.GetHashCode();
+            }
+        }
+
+        public enum DetectedIssue
+        {
+            Unknown = 0,
+            ManualReset = -1,
+            ManualDisconnect = -2,
+            ManualAbort = -3,
+            StopResponding = 1,
+            //StopMoving = 2, 
+            UnexpectedReset = 3,
+            UnexpectedDisconnect = 4,
+            MachineAlarm = 5,
+        }
+
+        public enum MacStatus
+        { Disconnected, Connecting, Idle, Run, Hold, Door, Home, Alarm, Check, Jog, Queue, Cooling, AutoHold, Tool } // "Tool" added in GrblHal
+
+        public enum JogDirection
+        { None, Abort, Home, N, S, W, E, NW, NE, SW, SE, Zup, Zdown }
+
+        public enum StreamingMode
+        { Buffered, Synchronous, RepeatOnError }
+
+        [Serializable]
+        public class GrblVersionInfo : IComparable, ICloneable
+        {
+            int mMajor;
+            int mMinor;
+            char mBuild;
+            bool mOrtur;
+            bool mGrblHal;
+
+            string mVendorInfo;
+            string mVendorVersion;
+
+            public GrblVersionInfo(int major, int minor, char build, string VendorInfo, string VendorVersion, bool IsHAL)
+            {
+                mMajor = major; mMinor = minor; mBuild = build;
+                mVendorInfo = VendorInfo;
+                mVendorVersion = VendorVersion;
+                mOrtur = VendorInfo != null && (VendorInfo.Contains("Ortur") || VendorInfo.Contains("Aufero"));
+                mGrblHal = IsHAL;
+            }
+
+            public GrblVersionInfo(int major, int minor, char build)
+            { mMajor = major; mMinor = minor; mBuild = build; }
+
+            public GrblVersionInfo(int major, int minor)
+            { mMajor = major; mMinor = minor; mBuild = (char)0; }
+
+            public static bool operator !=(GrblVersionInfo a, GrblVersionInfo b)
+            { return !(a == b); }
+
+            public static bool operator ==(GrblVersionInfo a, GrblVersionInfo b)
+            {
+                if (Object.ReferenceEquals(a, null))
+                    return Object.ReferenceEquals(b, null);
+                else
+                    return a.Equals(b);
+            }
+
+            public static bool operator <(GrblVersionInfo a, GrblVersionInfo b)
+            {
+                if ((Object)a == null)
+                    throw new ArgumentNullException("a");
+                return (a.CompareTo(b) < 0);
+            }
+
+            public static bool operator <=(GrblVersionInfo a, GrblVersionInfo b)
+            {
+                if ((Object)a == null)
+                    throw new ArgumentNullException("a");
+                return (a.CompareTo(b) <= 0);
+            }
+
+            public static bool operator >(GrblVersionInfo a, GrblVersionInfo b)
+            { return (b < a); }
+
+            public static bool operator >=(GrblVersionInfo a, GrblVersionInfo b)
+            { return (b <= a); }
+
+            public override string ToString()
+            {
+                if (mBuild == (char)0)
+                    return string.Format("{0}.{1}", mMajor, mMinor);
+                else
+                    return string.Format("{0}.{1}{2}", mMajor, mMinor, mBuild);
+            }
+
+            public override bool Equals(object obj)
+            {
+                GrblVersionInfo v = obj as GrblVersionInfo;
+                return v != null && this.mMajor == v.mMajor && this.mMinor == v.mMinor && this.mBuild == v.mBuild && this.mOrtur == v.mOrtur && this.mGrblHal == v.mGrblHal;
+            }
+
+            public override int GetHashCode()
+            {
+                unchecked
+                {
+                    int hash = 17;
+                    // Maybe nullity checks, if these are objects not primitives!
+                    hash = hash * 23 + mMajor.GetHashCode();
+                    hash = hash * 23 + mMinor.GetHashCode();
+                    hash = hash * 23 + mBuild.GetHashCode();
+                    hash = hash * 23 + mOrtur.GetHashCode();
+                    hash = hash * 23 + mGrblHal.GetHashCode();
+                    return hash;
+                }
+            }
+
+            public int CompareTo(Object version)
+            {
+                if (version == null)
+                    return 1;
+
+                GrblVersionInfo v = version as GrblVersionInfo;
+                if (v == null)
+                    throw new ArgumentException("Argument must be GrblVersionInfo");
+
+                if (this.mMajor != v.mMajor)
+                    if (this.mMajor > v.mMajor)
+                        return 1;
+                    else
+                        return -1;
+
+                if (this.mMinor != v.mMinor)
+                    if (this.mMinor > v.mMinor)
+                        return 1;
+                    else
+                        return -1;
+
+                if (this.mBuild != v.mBuild)
+                    if (this.mBuild > v.mBuild)
+                        return 1;
+                    else
+                        return -1;
+
+                return 0;
+            }
+
+            public object Clone()
+            { return this.MemberwiseClone(); }
+
+            public int Major => mMajor;
+            public int Minor => mMinor;
+            public bool IsOrtur => mOrtur;
+            public bool IsHAL => mGrblHal;
+            public bool IsLuckyOrturWiFi => IsOrtur && mVendorInfo == "Ortur Laser Master 3";
+            public string MachineName => mVendorInfo;
+
+            public string VendorName
+            {
+                get
+                {
+                    if (mVendorInfo != null && mVendorInfo.ToLower().Contains("ortur"))
+                        return "Ortur";
+                    else if (mVendorInfo != null && mVendorInfo.ToLower().Contains("Vigotec"))
+                        return "Vigotec";
+                    else if (mBuild == '#')
+                        return "Emulator";
+                    else
+                        return "Unknown";
+                }
+            }
+
+            public int OrturFWVersionNumber
+            {
+                get
+                {
+                    try { return int.Parse(mVendorVersion); }
+                    catch { return -1; }
+                }
+            }
+        }
+
+        public delegate void dlgIssueDetector(DetectedIssue issue);
+        public delegate void dlgOnMachineStatus();
+        public delegate void dlgOnOverrideChange();
+        public delegate void dlgOnLoopCountChange(decimal current);
+        public delegate void dlgJogStateChange(bool jog);
+
+        public event dlgIssueDetector IssueDetected;
+        public event dlgOnMachineStatus MachineStatusChanged;
+        public event GrblFile.OnFileLoadedDlg OnFileLoading;
+        public event GrblFile.OnFileLoadedDlg OnFileLoaded;
+        public event dlgOnOverrideChange OnOverrideChange;
+        public event dlgOnLoopCountChange OnLoopCountChange;
+        public event dlgJogStateChange JogStateChange;
+
+        private System.Windows.Forms.Control syncro;
+        protected ComWrapper.IComWrapper com;
+        private GrblFile file;
+        private System.Collections.Generic.Queue<GrblCommand> mQueue; //vera coda di quelli da mandare
+        private GrblCommand mRetryQueue; //coda[1] di quelli in attesa di risposta
+        private System.Collections.Generic.Queue<GrblCommand> mPending; //coda di quelli in attesa di risposta
+        private System.Collections.Generic.List<IGrblRow> mSent; //lista di quelli mandati
+
+        private System.Collections.Generic.Queue<GrblCommand> mQueuePtr; //puntatore a coda di quelli da mandare (normalmente punta a mQueue, salvo per import/export configurazione)
+        private System.Collections.Generic.List<IGrblRow> mSentPtr; //puntatore a lista di quelli mandati (normalmente punta a mSent, salvo per import/export configurazione)
+
+        private string mWelcomeSeen = null;
+        private string mVersionSeen = null;
+        protected int mUsedBuffer;
+
+        private const int DEFAULT_BUFFER_SIZE = 127;
+        private int mAutoBufferSize = DEFAULT_BUFFER_SIZE;
+        private GPoint mMPos;
+        private GPoint mWCO;
+        private int mGrblBlocks = -1;
+        private int mGrblBuffer = -1;
+        private int mFailedConnection = 0;
+        private JogDirection mPrenotedJogDirection = JogDirection.None;
+        private float mPrenotedJogSpeed = 100;
+        protected TimeProjection mTP = new TimeProjection();
+
+        private MacStatus mMachineStatus = MacStatus.Disconnected;
+
+
+        private float mCurF;
+        private float mCurS;
+
+        private int mCurOvLinear;
+        private int mCurOvRapids;
+        private int mCurOvPower;
+
+        private int mTarOvLinear;
+        private int mTarOvRapids;
+        private int mTarOvPower;
+
+        private decimal mLoopCount = 1;
+
+        protected Tools.PeriodicEventTimer QueryTimer;
+
+        private Tools.ThreadObject TX;
+        private Tools.ThreadObject RX;
+
+        private long connectStart;
+
+        protected ElapsedFromEvent debugLastStatusDelay;
+        protected ElapsedFromEvent debugLastMoveOrActivityDelay;
+
+        private ThreadingMode mThreadingMode = ThreadingMode.Fast;
+        private HotKeysManager mHotKeyManager;
+
+        public UsageStats.UsageCounters UsageCounters;
+
+        private string mDetectedIP = null;
+        private bool mDoingSend = false;
+
+
+
+        public GrblCore(System.Windows.Forms.Control syncroObject, PreviewForm cbform, JogForm jogform)
+        {
+            if (Type != Firmware.Grbl) Logger.LogMessage("Program", "Load {0} core", Type);
+
+            SetStatus(MacStatus.Disconnected);
+            syncro = syncroObject;
+            com = new ComWrapper.UsbSerial();
+
+            debugLastStatusDelay = new ElapsedFromEvent();
+            debugLastMoveOrActivityDelay = new ElapsedFromEvent();
+
+            //with version 4.5.0 default ThreadingMode change from "UltraFast" to "Fast"
+            if (!Settings.IsNewFile && Settings.PrevVersion < new Version(4, 5, 0))
+            {
+                ThreadingMode CurrentMode = Settings.GetObject("Threading Mode", ThreadingMode.Fast);
+                if (Equals(CurrentMode, ThreadingMode.Insane) || Equals(CurrentMode, ThreadingMode.UltraFast))
+                    Settings.SetObject("Threading Mode", ThreadingMode.Fast);
+            }
+
+            mThreadingMode = Settings.GetObject("Threading Mode", ThreadingMode.Fast);
+
+
+
+            QueryTimer = new Tools.PeriodicEventTimer(TimeSpan.FromMilliseconds(mThreadingMode.StatusQuery), false);
+            TX = new Tools.ThreadObject(ThreadTX, 1, true, "Serial TX Thread", StartTX);
+            RX = new Tools.ThreadObject(ThreadRX, 1, true, "Serial RX Thread", null);
+
+            file = new GrblFile(0, 0, Configuration.TableWidth, Configuration.TableHeight);  //create a fake range to use with manual movements
+
+            file.OnFileLoading += RiseOnFileLoading;
+            file.OnFileLoaded += RiseOnFileLoaded;
+
+            mQueue = new System.Collections.Generic.Queue<GrblCommand>();
+            mPending = new System.Collections.Generic.Queue<GrblCommand>();
+            mSent = new System.Collections.Generic.List<IGrblRow>();
+            mUsedBuffer = 0;
+
+            mSentPtr = mSent;
+            mQueuePtr = mQueue;
+
+            mCurOvLinear = mCurOvRapids = mCurOvPower = 100;
+            mTarOvLinear = mTarOvRapids = mTarOvPower = 100;
+
+            if (!Settings.ExistObject("Hotkey Setup")) Settings.SetObject("Hotkey Setup", new HotKeysManager());
+            mHotKeyManager = Settings.GetObject<HotKeysManager>("Hotkey Setup", null);
+            mHotKeyManager.Init(this, cbform, jogform);
+
+            UsageCounters = new UsageStats.UsageCounters();
+
+            if (GrblVersion != null)
+                CSVD.LoadAppropriateCSV(GrblVersion); //load setting for last known version
+        }
+
+        internal void HotKeyOverride(HotKeysManager.HotKey.Actions action)
+        {
+
+            switch (action)
+            {
+                case HotKeysManager.HotKey.Actions.OverridePowerDefault:
+                    mTarOvPower = 100; break;
+                case HotKeysManager.HotKey.Actions.OverridePowerUp:
+                    mTarOvPower = Math.Min(mTarOvPower + 1, 200); break;
+                case HotKeysManager.HotKey.Actions.OverridePowerDown:
+                    mTarOvPower = Math.Max(mTarOvPower - 1, 10); break;
+                case HotKeysManager.HotKey.Actions.OverrideLinearDefault:
+                    mTarOvLinear = 100; break;
+                case HotKeysManager.HotKey.Actions.OverrideLinearUp:
+                    mTarOvLinear = Math.Min(mTarOvLinear + 1, 200); break;
+                case HotKeysManager.HotKey.Actions.OverrideLinearDown:
+                    mTarOvLinear = Math.Max(mTarOvLinear - 1, 10); break;
+                case HotKeysManager.HotKey.Actions.OverrideRapidDefault:
+                    mTarOvRapids = 100; break;
+                case HotKeysManager.HotKey.Actions.OverrideRapidUp:
+                    mTarOvRapids = Math.Min(mTarOvRapids * 2, 100); break;
+                case HotKeysManager.HotKey.Actions.OverrideRapidDown:
+                    mTarOvRapids = Math.Max(mTarOvRapids / 2, 25); break;
+                default:
+                    break;
+            }
+        }
+
+        internal string ValidateConfig(int parid, object value)
+        {
+            if (Configuration == null)
+                return null;
+
+            return Configuration.ValidateConfig(parid, value);
+        }
+
+        public virtual Firmware Type
+        { get { return Firmware.Grbl; } }
+
+        public static GrblConfST Configuration
+        {
+            get
+            {
+                if (Settings.ExistObject("Grbl Configuration"))
+                {
+                    Settings.SetObject("Grbl Configuration ST", new GrblConfST(Settings.GetObject("Grbl Configuration", (GrblConf)null)));  //convert old format with only numbers
+                    Settings.DeleteObject("Grbl Configuration");                                                                            //delete old format
+                }
+                return Settings.GetObject("Grbl Configuration ST", new GrblConfST());
+            }
+            set
+            {
+                if (value.Count > 0 && value.GrblVersion != null)
+                    Settings.SetObject("Grbl Configuration ST", value);
+            }
+        }
+
+        protected void SetStatus(MacStatus newStatus)
+        {
+            lock (this)
+            {
+                LaserLifeHandler.ComputeLaserTime(mMachineStatus);
+
+                if (mMachineStatus != newStatus)
+                {
+                    MacStatus oldStatus = mMachineStatus;
+                    mMachineStatus = newStatus;
+
+                    Logger.LogMessage("SetStatus", "Machine status [{0}]", mMachineStatus);
+                    if (oldStatus == MacStatus.Connecting && newStatus == MacStatus.Disconnected)
+                        mFailedConnection++;
+                    if (oldStatus == MacStatus.Connecting && newStatus != MacStatus.Disconnected)
+                        mFailedConnection = 0;
+                    if (oldStatus == MacStatus.Connecting && newStatus != MacStatus.Disconnected)
+                        RefreshConfigOnConnect();
+                    if (oldStatus == MacStatus.Connecting && newStatus != MacStatus.Disconnected)
+                        SoundEvent.PlaySound(SoundEvent.EventId.Connect);
+                    if (newStatus == MacStatus.Disconnected)
+                        SoundEvent.PlaySound(SoundEvent.EventId.Disconnect);
+                    if (IsAnyHoldState(oldStatus) && !IsAnyHoldState(newStatus))
+                        mHoldByCoolingRequest = mHoldByUserRequest = false; //se sto uscendo da uno stato di hold per qualsiasi motivo (tipo un reset o altro) mi tolgo l'userHold e il coolingHold
+
+                    RiseMachineStatusChanged();
+
+                    if (mTP != null && mTP.InProgram)
+                    {
+                        if (InPause)
+                            mTP.JobPause();
+                        else
+                            mTP.JobResume();
+                    }
+
+                    if (newStatus == MacStatus.Disconnected)
+                        SetFS(0, 0);
+                }
+            }
+        }
+
+        private static bool IsAnyHoldState(MacStatus status)
+        {
+            return status == MacStatus.Hold || status == MacStatus.Cooling || status == MacStatus.AutoHold;
+        }
+
+        private void RefreshConfigOnConnect()
+        {
+            try { System.Threading.ThreadPool.QueueUserWorkItem(new System.Threading.WaitCallback(RefreshConfigOnConnect)); }
+            catch { }
+        }
+
+        internal virtual void SendHomingCommand()
+        {
+            EnqueueCommand(new GrblCommand("$H"));
+        }
+
+        internal virtual void SendUnlockCommand()
+        {
+            EnqueueCommand(new GrblCommand("$X"));
+        }
+
+        public GrblVersionInfo GrblVersion //attenzione! può essere null
+        {
+            get { return Settings.GetObject<GrblVersionInfo>("Last GrblVersion known", null); }
+            set
+            {
+                if (GrblVersion != null)
+                    Logger.LogMessage("VersionInfo", "Detected Grbl v{0}", value);
+
+                if (GrblVersion == null || !GrblVersion.Equals(value))
+                {
+                    CSVD.LoadAppropriateCSV(value);
+                    Settings.SetObject("Last GrblVersion known", value);
+                }
+            }
+        }
+
+        protected void SetIssue(DetectedIssue issue)
+        {
+            mTP.JobIssue(issue);
+            Logger.LogMessage("Issue detector", "{0} [{1},{2},{3}]", issue, FreeBuffer, GrblBuffer, GrblBlock);
+
+            if (issue > 0) //negative numbers indicate issue caused by the user, so must not be report to UI
+            {
+                RiseIssueDetected(issue);
+                Telegram.NotifyEvent(String.Format("<b>Job Issue</b>\n{0}", issue));
+                SoundEvent.PlaySound(SoundEvent.EventId.Fatal);
+            }
+        }
+
+        void RiseJogStateChange(bool jog)
+        {
+            if (JogStateChange != null)
+            {
+                if (syncro.InvokeRequired)
+                    syncro.BeginInvoke(new dlgJogStateChange(RiseJogStateChange), jog);
+                else
+                    JogStateChange(jog);
+            }
+        }
+
+        void RiseIssueDetected(DetectedIssue issue)
+        {
+            if (IssueDetected != null)
+            {
+                if (syncro.InvokeRequired)
+                    syncro.BeginInvoke(new dlgIssueDetector(RiseIssueDetected), issue);
+                else
+                    IssueDetected(issue);
+            }
+        }
+
+        void RiseMachineStatusChanged()
+        {
+            if (MachineStatusChanged != null)
+            {
+                if (syncro.InvokeRequired)
+                    syncro.BeginInvoke(new dlgOnMachineStatus(RiseMachineStatusChanged));
+                else
+                    MachineStatusChanged();
+            }
+        }
+
+        void RiseOverrideChanged()
+        {
+            if (OnOverrideChange != null)
+            {
+                if (syncro.InvokeRequired)
+                    syncro.BeginInvoke(new dlgOnOverrideChange(RiseOverrideChanged));
+                else
+                    OnOverrideChange();
+            }
+        }
+
+        void RiseOnFileLoading(long elapsed, string filename)
+        {
+            mTP.Reset(true);
+
+            if (OnFileLoaded != null)
+                OnFileLoading(elapsed, filename);
+        }
+
+        void RiseOnFileLoaded(long elapsed, string filename)
+        {
+            mTP.Reset(true);
+
+            if (OnFileLoaded != null)
+                OnFileLoaded(elapsed, filename);
+        }
+
+        public GrblFile LoadedFile
+        { get { return file; } }
+
+        public void ReOpenFile(System.Windows.Forms.Form parent)
+        {
+            if (CanReOpenFile)
+                OpenFile(parent, Settings.GetObject<string>("Core.LastOpenFile", null));
+        }
+
+        public static readonly List<string> ImageExtensions = new List<string>(new string[] { ".jpg", ".jpeg", ".bmp", ".png", ".gif" });
+        public static readonly List<string> GCodeExtensions = new List<string>(new string[] { ".nc", ".cnc", ".tap", ".gcode", ".ngc" });
+        public static readonly List<string> ProjectFileExtensions = new List<string>(new string[] { ".lps" });
+        public void OpenFile(System.Windows.Forms.Form parent, string filename = null, bool append = false)
+        {
+            if (!CanLoadNewFile) return;
+
+            try
+            {
+                if (filename == null)
+                {
+                    using (System.Windows.Forms.OpenFileDialog ofd = new System.Windows.Forms.OpenFileDialog())
+                    {
+                        //pre-select last file if exist
+                        string lastFN = Settings.GetObject<string>("Core.LastOpenFile", null);
+                        if (lastFN != null && System.IO.File.Exists(lastFN))
+                            ofd.FileName = lastFN;
+
+                        ofd.Filter = "Any supported file|*.nc;*.cnc;*.tap;*.gcode;*.ngc;*.bmp;*.png;*.jpg;*.jpeg;*.gif;*.svg;*.lps|GCODE Files|*.nc;*.cnc;*.tap;*.gcode;*.ngc|Raster Image|*.bmp;*.png;*.jpg;*.jpeg;*.gif|Vector Image (experimental)|*.svg|LaserGRBL Project|*.lps";
+                        ofd.CheckFileExists = true;
+                        ofd.Multiselect = false;
+                        ofd.RestoreDirectory = true;
+
+                        System.Windows.Forms.DialogResult dialogResult = System.Windows.Forms.DialogResult.Cancel;
+                        try
+                        {
+                            dialogResult = ofd.ShowDialog(parent);
+                        }
+                        catch (System.Runtime.InteropServices.COMException)
+                        {
+                            ofd.AutoUpgradeEnabled = false;
+                            dialogResult = ofd.ShowDialog(parent);
+                        }
+
+                        if (dialogResult == System.Windows.Forms.DialogResult.OK)
+                            filename = ofd.FileName;
+                    }
+                }
+
+                if (filename == null) return;
+
+                Logger.LogMessage("OpenFile", "Open {0}", filename);
+                Settings.SetObject("Core.LastOpenFile", filename);
+
+                if (ImageExtensions.Contains(System.IO.Path.GetExtension(filename).ToLowerInvariant())) //import raster image
+                {
+                    try
+                    {
+                        RasterConverter.RasterToLaserForm.CreateAndShowDialog(this, filename, parent, append);
+                        UsageCounters.RasterFile++;
+                    }
+                    catch (Exception ex)
+                    { Logger.LogException("RasterImport", ex); }
+                }
+                else if (System.IO.Path.GetExtension(filename).ToLowerInvariant() == ".svg")
+                {
+                    SvgConverter.SvgModeForm.Mode mode = SvgConverter.SvgModeForm.Mode.Vector;// SvgConverter.SvgModeForm.CreateAndShow(filename);
+                    if (mode == SvgConverter.SvgModeForm.Mode.Vector)
+                    {
+                        try
+                        {
+                            SvgConverter.SvgToGCodeForm.CreateAndShowDialog(this, filename, parent, append);
+                            UsageCounters.SvgFile++;
+                        }
+                        catch (Exception ex)
+                        { Logger.LogException("SvgImport", ex); }
+                    }
+                    else if (mode == SvgConverter.SvgModeForm.Mode.Raster)
+                    {
+                        string bmpname = filename + ".png";
+                        string fcontent = System.IO.File.ReadAllText(filename);
+                        Svg.SvgDocument svg = Svg.SvgDocument.FromSvg<Svg.SvgDocument>(fcontent);
+                        svg.Ppi = 600;
+
+                        using (Bitmap bmp = svg.Draw())
+                        {
+                            bmp.SetResolution(600, 600);
+
+                            //codec options not supported in C# png encoder https://efundies.com/c-sharp-save-png/
+                            //quality always 100%
+
+                            //ImageCodecInfo codecinfo = GetEncoder(ImageFormat.Png);
+                            //EncoderParameters paramlist = new EncoderParameters(1);
+                            //paramlist.Param[0] = new EncoderParameter(Encoder.Quality, 30L); 
+
+
+                            if (System.IO.File.Exists(bmpname))
+                                System.IO.File.Delete(bmpname);
+
+                            bmp.Save(bmpname/*, codecinfo, paramlist*/);
+                        }
+
+                        try
+                        {
+                            RasterConverter.RasterToLaserForm.CreateAndShowDialog(this, bmpname, parent, append);
+                            UsageCounters.RasterFile++;
+                            if (System.IO.File.Exists(bmpname))
+                                System.IO.File.Delete(bmpname);
+                        }
+                        catch (Exception ex)
+                        { Logger.LogException("SvgBmpImport", ex); }
+                    }
+                }
+                else if (GCodeExtensions.Contains(System.IO.Path.GetExtension(filename).ToLowerInvariant()))  //load GCODE file
+                {
+                    Cursor.Current = Cursors.WaitCursor;
+
+                    try
+                    {
+                        file.LoadFile(filename, append);
+                        UsageCounters.GCodeFile++;
+                    }
+                    catch (Exception ex)
+                    { Logger.LogException("GCodeImport", ex); }
+
+                    Cursor.Current = Cursors.Default;
+                }
+                else if (ProjectFileExtensions.Contains(System.IO.Path.GetExtension(filename).ToLowerInvariant()))  //load LaserGRBL project
+                {
+                    var project = Project.LoadProject(filename);
+
+                    for (var i = 0; i < project.Count; i++)
+                    {
+                        var settings = project[i];
+
+                        // Save image temporary
+                        var imageFilepath = $"{System.IO.Path.GetTempPath()}\\{settings["ImageName"]}";
+                        Project.SaveImage(settings["ImageBase64"].ToString(), imageFilepath);
+
+                        // Restore settings
+                        foreach (var setting in settings.Where(setting =>
+                            setting.Key != "ImageName" && setting.Key != "ImageBase64"))
+                            Settings.SetObject(setting.Key, setting.Value);
+
+                        // Open file
+                        Settings.SetObject("Core.LastOpenFile", imageFilepath);
+                        if (i == 0)
+                            ReOpenFile(parent);
+                        else
+                            OpenFile(parent, imageFilepath, true);
+
+                        // Delete temporary image file
+                        System.IO.File.Delete(imageFilepath);
+                    }
+                }
+                else
+                {
+                    System.Windows.Forms.MessageBox.Show(Strings.UnsupportedFiletype, "Error", System.Windows.Forms.MessageBoxButtons.OK, System.Windows.Forms.MessageBoxIcon.Error);
+                }
+            }
+            catch (Exception ex)
+            {
+                Logger.LogException("OpenFile", ex);
+            }
+        }
+
+        private ImageCodecInfo GetEncoder(ImageFormat format)
+        {
+            ImageCodecInfo[] codecs = ImageCodecInfo.GetImageDecoders();
+            foreach (ImageCodecInfo codec in codecs)
+            {
+                if (codec.FormatID == format.Guid)
+                {
+                    return codec;
+                }
+            }
+            return null;
+        }
+
+        public void SaveProgram(Form parent, bool header, bool footer, bool between, int cycles, bool useLFLineEndings)
+        {
+            if (HasProgram)
+            {
+                string filename = null;
+                using (SaveFileDialog sfd = new SaveFileDialog())
+                {
+                    string lastFN = Settings.GetObject<string>("Core.LastOpenFile", null);
+                    if (lastFN != null)
+                    {
+                        string fn = System.IO.Path.GetFileNameWithoutExtension(lastFN);
+                        string path = System.IO.Path.GetDirectoryName(lastFN);
+                        sfd.FileName = System.IO.Path.Combine(path, fn + ".nc");
+                    }
+
+                    sfd.Filter = "GCODE Files|*.nc";
+                    sfd.AddExtension = true;
+                    sfd.RestoreDirectory = true;
+
+                    DialogResult rv = DialogResult.Cancel;
+                    try
+                    {
+                        rv = sfd.ShowDialog(parent);
+                    }
+                    catch (System.Runtime.InteropServices.COMException)
+                    {
+                        sfd.AutoUpgradeEnabled = false;
+                        rv = sfd.ShowDialog(parent);
+                    }
+
+                    if (rv == DialogResult.OK)
+                        filename = sfd.FileName;
+                }
+
+                if (filename != null)
+                    file.SaveGCODE(filename, header, footer, between, cycles, useLFLineEndings, this);
+            }
+        }
+
+        public void SaveProject(Form parent)
+        {
+            if (HasProgram)
+            {
+                string filename = null;
+                using (SaveFileDialog sfd = new SaveFileDialog())
+                {
+                    string lastFN = Settings.GetObject<string>("Core.LastOpenFile", null);
+                    if (lastFN != null)
+                    {
+                        string fn = System.IO.Path.GetFileNameWithoutExtension(lastFN);
+                        string path = System.IO.Path.GetDirectoryName(lastFN);
+                        sfd.FileName = System.IO.Path.Combine(path, fn + ".lps");
+                    }
+
+                    sfd.Filter = "LaserGRBL Project|*.lps";
+                    sfd.AddExtension = true;
+                    sfd.RestoreDirectory = true;
+
+                    DialogResult rv = DialogResult.Cancel;
+                    try
+                    {
+                        rv = sfd.ShowDialog(parent);
+                    }
+                    catch (System.Runtime.InteropServices.COMException)
+                    {
+                        sfd.AutoUpgradeEnabled = false;
+                        rv = sfd.ShowDialog(parent);
+                    }
+
+                    if (rv == DialogResult.OK)
+                        filename = sfd.FileName;
+                }
+
+                if (filename != null)
+                    Project.StoreSettings(filename);
+            }
+        }
+
+        private void RefreshConfigOnConnect(object state) //da usare per la chiamata asincrona
+        {
+            System.Threading.Thread.Sleep(500); //allow the machine to send all the startup messages before refreshing config and info
+
+            try
+            {
+                RefreshConfig(RefreshCause.OnConnect);
+            }
+            catch (Exception ex) { Logger.LogMessage("Refresh Config", ex.Message); }
+
+            try { RefreshMachineInfo(); }
+            catch (Exception ex) { Logger.LogMessage("Refresh Config", ex.Message); }
+        }
+
+        public virtual void RefreshMachineInfo()
+        {
+            if (Settings.GetObject("Query MachineInfo ($I) at connect", true))
+            {
+                try
+                {
+                    //GrblConf conf = new GrblConf(GrblVersion);
+                    GrblCommand cmd = new GrblCommand("$I");
+
+                    lock (this)
+                    {
+                        mSentPtr = new List<IGrblRow>(); //assign sent queue
+                        mQueuePtr = new Queue<GrblCommand>();
+                        mQueuePtr.Enqueue(cmd);
+                    }
+
+                    Tools.PeriodicEventTimer WaitResponseTimeout = new Tools.PeriodicEventTimer(TimeSpan.FromSeconds(10), true);
+
+                    //resta in attesa dell'invio del comando e della risposta
+                    while (cmd.Status == GrblCommand.CommandStatus.Queued || cmd.Status == GrblCommand.CommandStatus.WaitingResponse)
+                    {
+                        if (WaitResponseTimeout.Expired)
+                            throw new TimeoutException("No response received from grbl!");
+                        else
+                            System.Threading.Thread.Sleep(10);
+                    }
+
+                    if (cmd.Status == GrblCommand.CommandStatus.ResponseGood)
+                    {
+                        //attendi la ricezione di tutti i parametri
+                        long tStart = Tools.HiResTimer.TotalMilliseconds;
+                        long tLast = tStart;
+                        int counter = mSentPtr.Count;
+                        int target = 2 + 1; //il +1 è il comando $I
+
+                        //finché ne devo ricevere ancora && l'ultima risposta è più recente di 500mS && non sono passati più di 5s totali
+                        while (mSentPtr.Count < target && Tools.HiResTimer.TotalMilliseconds - tLast < 500 && Tools.HiResTimer.TotalMilliseconds - tStart < 5000)
+                        {
+                            if (mSentPtr.Count != counter)
+                            { tLast = Tools.HiResTimer.TotalMilliseconds; counter = mSentPtr.Count; }
+                            else
+                                System.Threading.Thread.Sleep(10);
+                        }
+
+                        foreach (IGrblRow row in mSentPtr) //read the reply
+                        {
+                            string rline = row.GetDecodedMessage();
+                            if (IsIVerMessage(rline))
+                                ManageVerMessage(rline);
+                            else if (IsIOptMessage(rline))
+                                ManageOptMessage(rline);
+                        }
+                    }
+                }
+                finally
+                {
+                    lock (this)
+                    {
+                        mQueuePtr = mQueue;
+                        mSentPtr = mSent; //restore queue
+                    }
+                }
+            }
+        }
+
+        private void ManageOptMessage(string rline)
+        {
+            try
+            {
+                rline = rline.Substring(5, rline.Length - 6);
+                string[] arr = rline.Split(',');
+                string letters = arr.Length > 0 ? arr[0] : null;
+                int bbuffer = arr.Length > 1 ? int.Parse(arr[1]) : 0;
+                int txbuffer = arr.Length > 2 ? int.Parse(arr[2]) : 0;
+
+                if (txbuffer > DEFAULT_BUFFER_SIZE) //more then default buffer size
+                    EnlargeBuffer(txbuffer, true);
+
+            }
+            catch (Exception ex)
+            {
+                Logger.LogMessage("OptionsMessage", "Ex on [{0}] message", rline);
+                Logger.LogException("OptionsMessage", ex);
+            }
+        }
+
+        private void ManageVerMessage(string rline)
+        {
+            try
+            {
+                rline = rline.Substring(5, rline.Length - 6);
+                //if (rline.ToLower().Contains("neje"))
+                //    GrblVersion?.IsNeje = true;
+            }
+            catch (Exception ex)
+            {
+                Logger.LogMessage("VersionMessage", "Ex on [{0}] message", rline);
+                Logger.LogException("VersionMessage", ex);
+            }
+        }
+
+        public enum RefreshCause { OnConnect, OnDialog, OnRead, OnExport, OnImport, OnWriteBegin, OnWriteEnd }
+        public virtual void RefreshConfig(RefreshCause cause)
+        {
+            if (CanReadWriteConfig)
+            {
+                try
+                {
+                    Logger.LogMessage("Refresh Config", "Refreshing grbl configuration [{0}]", cause);
+
+                    GrblConfST conf = new GrblConfST(GrblVersion);
+                    GrblCommand cmd = new GrblCommand("$$");
+
+                    lock (this)
+                    {
+                        mSentPtr = new List<IGrblRow>(); //assign sent queue
+                        mQueuePtr = new Queue<GrblCommand>();
+                        mQueuePtr.Enqueue(cmd);
+                    }
+
+                    PeriodicEventTimer WaitResponseTimeout = new PeriodicEventTimer(TimeSpan.FromSeconds(10), true);
+
+                    //resta in attesa dell'invio del comando e della risposta
+                    while (cmd.Status == GrblCommand.CommandStatus.Queued || cmd.Status == GrblCommand.CommandStatus.WaitingResponse)
+                    {
+                        if (WaitResponseTimeout.Expired)
+                            throw new TimeoutException("No response received from grbl!");
+                        else
+                            System.Threading.Thread.Sleep(10);
+                    }
+
+                    if (cmd.Status == GrblCommand.CommandStatus.ResponseGood)
+                    {
+                        //attendi la ricezione di tutti i parametri
+                        long tStart = Tools.HiResTimer.TotalMilliseconds;
+                        long tLast = tStart;
+                        int counter = mSentPtr.Count;
+                        int target = conf.ExpectedCount + 1; //il +1 è il comando $$
+
+                        //finché ne devo ricevere ancora && l'ultima risposta è più recente di 500mS && non sono passati più di 5s totali
+                        while (mSentPtr.Count < target && HiResTimer.TotalMilliseconds - tLast < 500 && Tools.HiResTimer.TotalMilliseconds - tStart < 5000)
+                        {
+                            if (mSentPtr.Count != counter)
+                            { tLast = HiResTimer.TotalMilliseconds; counter = mSentPtr.Count; }
+                            else
+                                System.Threading.Thread.Sleep(10);
+                        }
+
+                        foreach (IGrblRow row in mSentPtr)
+                        {
+                            if (row is GrblMessage)
+                                conf.AddOrUpdate(((GrblMessage)row).GetNativeMessage());
+                        }
+
+                        Configuration = conf; //accept configuration
+
+                        if (conf.Count < conf.ExpectedCount) //log but do not show error if some param is missing
+                            Logger.LogMessage("Refresh Config", "Wrong number of config param found! (Expected: {0} Found: {1})", conf.Count, conf.ExpectedCount);
+                        else
+                            Logger.LogMessage("Refresh Config", "Configuration successfully received! (Expected: {0} Found: {1})", conf.Count, conf.ExpectedCount);
+                    }
+                }
+                catch (Exception ex)
+                {
+                    Logger.LogException("Refresh Config", ex);
+                    throw ex;
+                }
+                finally
+                {
+                    lock (this)
+                    {
+                        mQueuePtr = mQueue;
+                        mSentPtr = mSent; //restore queue
+                    }
+                }
+            }
+            else
+            {
+                Logger.LogMessage("Refresh Config", "Cannot refresh config now [{0}] [Connected:{1} Program:{2} Status:{3}]", cause, IsConnected, InProgram, MachineStatus);
+            }
+        }
+
+
+
+        public class ReadConfigCountException : Exception
+        {
+            public ReadConfigCountException(string message) : base(message)
+            {
+            }
+        }
+
+        public class WriteConfigException : Exception
+        {
+            private System.Collections.Generic.List<IGrblRow> ErrorLines = new System.Collections.Generic.List<IGrblRow>();
+
+            public WriteConfigException(System.Collections.Generic.List<IGrblRow> mSentPtr)
+            {
+                foreach (IGrblRow row in mSentPtr)
+                    if (row is GrblCommand)
+                        if (((GrblCommand)row).Status != GrblCommand.CommandStatus.ResponseGood)
+                            ErrorLines.Add(row);
+            }
+
+            public override string Message
+            {
+                get
+                {
+                    string rv = "";
+                    foreach (IGrblRow r in ErrorLines)
+                        rv += string.Format("{0} {1}\n", r.GetDecodedMessage(), r.GetResult(true, false));
+                    return rv.Trim();
+                }
+            }
+
+            public List<IGrblRow> Errors
+            { get { return ErrorLines; } }
+        }
+
+        public string DetectedIP => mDetectedIP;
+
+        internal void WriteWiFiConfig(string ssid, string password)
+        {
+            //throw new NotImplementedException();
+            mDetectedIP = null;
+            if (CanReadWriteConfig)
+            {
+                lock (this)
+                {
+                    //mSentPtr = new System.Collections.Generic.List<IGrblRow>(); //assign sent queue
+                    //mQueuePtr = new System.Collections.Generic.Queue<GrblCommand>();
+
+                    mQueuePtr.Enqueue(new GrblCommand(string.Format("${0}={1}", 74, ssid), 0, true));
+                    mQueuePtr.Enqueue(new GrblCommand(string.Format("${0}={1}", 75, password), 0, true));
+                    mQueuePtr.Enqueue(new GrblCommand("$WRS"));
+                }
+
+                try
+                {
+                    while (com.IsOpen && (mQueuePtr.Count > 0 || HasPendingCommands())) //resta in attesa del completamento della comunicazione
+                        ;
+
+                    int errors = 0;
+                    foreach (IGrblRow row in mSentPtr)
+                    {
+                        if (row is GrblCommand)
+                            if (((GrblCommand)row).Status != GrblCommand.CommandStatus.ResponseGood)
+                                errors++;
+                    }
+
+                    //if (errors > 0)
+                    //	throw new WriteConfigException(mSentPtr);
+                }
+                catch (Exception ex)
+                {
+                    //Logger.LogException("Write Config", ex);
+                    //throw (ex);
+                }
+                finally
+                {
+                    //lock (this)
+                    //{
+                    //	//mQueuePtr = mQueue;
+                    //	//mSentPtr = mSent; //restore queue
+                    //}
+                }
+            }
+
+        }
+
+        public void WriteConfig(List<GrblConfST.GrblConfParam> config)
+        {
+            if (CanReadWriteConfig)
+            {
+                lock (this)
+                {
+                    mSentPtr = new System.Collections.Generic.List<IGrblRow>(); //assign sent queue
+                    mQueuePtr = new System.Collections.Generic.Queue<GrblCommand>();
+
+                    foreach (GrblConfST.GrblConfParam p in config)
+                        mQueuePtr.Enqueue(new GrblCommand(string.Format("${0}={1}", p.Number, p.Value), 0, true));
+                }
+
+                try
+                {
+                    while (com.IsOpen && (mQueuePtr.Count > 0 || HasPendingCommands())) //resta in attesa del completamento della comunicazione
+                        ;
+
+                    int errors = 0;
+                    foreach (IGrblRow row in mSentPtr)
+                    {
+                        if (row is GrblCommand)
+                            if (((GrblCommand)row).Status != GrblCommand.CommandStatus.ResponseGood)
+                                errors++;
+                    }
+
+                    if (errors > 0)
+                        throw new WriteConfigException(mSentPtr);
+                }
+                catch (Exception ex)
+                {
+                    Logger.LogException("Write Config", ex);
+                    throw (ex);
+                }
+                finally
+                {
+                    lock (this)
+                    {
+                        mQueuePtr = mQueue;
+                        mSentPtr = mSent; //restore queue
+                    }
+                }
+            }
+        }
+
+
+        public void RunProgram(Form parent)
+        {
+            try
+            {
+                if (CanSendFile)
+                {
+                    mDoingSend = true;
+
+                    if (mTP.Executed == 0 || mTP.Executed == mTP.Target) //mai iniziato oppure correttamente finito
+                        RunProgramFromStart(false, true);
+                    else
+                        UserWantToContinue(parent);
+                }
+            }
+            catch { }
+            finally { mDoingSend = false; }
+        }
+
+        public void AbortProgram()
+        {
+            if (CanAbortProgram)
+            {
+                try
+                {
+                    Logger.LogMessage("ManualAbort", "Program aborted by user action!");
+
+                    SetIssue(DetectedIssue.ManualAbort);
+                    mTP.JobEnd(true);
+
+                    lock (this)
+                    {
+                        mQueue.Clear(); //flush the queue of item to send
+                        mQueue.Enqueue(new GrblCommand("M5")); //shut down laser
+                    }
+                }
+                catch (Exception ex)
+                {
+                    Logger.LogException("Abort Program", ex);
+                }
+
+            }
+        }
+
+        public void RunProgramFromPosition(Form parent)
+        {
+            if (CanSendFile)
+            {
+                bool homing = false;
+                int position = LaserGRBL.RunFromPositionForm.CreateAndShowDialog(parent, LoadedFile.Count, Configuration.HomingEnabled, out homing);
+
+                if (position >= 0)
+                    ContinueProgramFromKnown(position, homing, false);
+            }
+        }
+
+        private void UserWantToContinue(Form parent)
+        {
+            bool setwco = mWCO == GPoint.Zero && mTP.LastKnownWCO != GPoint.Zero;
+            bool homing = MachinePosition == GPoint.Zero && mTP.LastIssue != DetectedIssue.ManualAbort && mTP.LastIssue != DetectedIssue.ManualReset; //potrebbe essere dovuto ad un hard reset -> posizione non affidabile
+            int position = ResumeJobForm.CreateAndShowDialog(parent, mTP.Executed, mTP.Sent, mTP.Target, mTP.LastIssue, Configuration.HomingEnabled, homing, out homing, setwco, setwco, out setwco, mTP.LastKnownWCO);
+
+            if (position == 0)
+                RunProgramFromStart(homing);
+            if (position > 0)
+                ContinueProgramFromKnown(position, homing, setwco);
+        }
+
+        private void RunProgramFromStart(bool homing, bool first = false, bool pass = false)
+        {
+            //solo se non siamo tra le passate
+            if (!pass && !SafetyCountdown.CanGo())
+                return;
+
+            lock (this)
+            {
+                ClearQueue(true);
+
+                mTP.Reset(first);
+
+                if (homing)
+                {
+                    Logger.LogMessage("EnqueueProgram", "Push Homing ($H)");
+                    mQueuePtr.Enqueue(new GrblCommand("$H"));
+                }
+
+                if (first)
+                    OnJobBegin();
+
+                if (pass)
+                    OnJobCycle();
+
+
+                Logger.LogMessage("EnqueueProgram", "Push File, {0} lines", file.Count);
+                foreach (GrblCommand cmd in file)
+                    mQueuePtr.Enqueue(cmd.Clone() as GrblCommand);
+
+                mTP.JobStart(LoadedFile, mQueuePtr, first);
+                Logger.LogMessage("EnqueueProgram", "Running program, {0} lines", file.Count);
+            }
+        }
+
+        private void OnJobCycle()
+        {
+            Logger.LogMessage("EnqueueProgram", "Push Passes");
+            ExecuteCustombutton(Settings.GetObject("GCode.CustomPasses", GrblCore.GCODE_STD_PASSES));
+        }
+
+        protected virtual void OnJobBegin()
+        {
+            Logger.LogMessage("EnqueueProgram", "Push Header");
+            ExecuteCustombutton(Settings.GetObject("GCode.CustomHeader", GrblCore.GCODE_STD_HEADER));
+        }
+
+        protected virtual void OnJobEnd()
+        {
+            Logger.LogMessage("EnqueueProgram", "Push Footer");
+            ExecuteCustombutton(Settings.GetObject("GCode.CustomFooter", GrblCore.GCODE_STD_FOOTER));
+        }
+
+        private void ContinueProgramFromKnown(int position, bool homing, bool setwco)
+        {
+            if (!SafetyCountdown.CanGo())
+                return;
+
+            lock (this)
+            {
+
+                ClearQueue(false); //lascia l'eventuale lista delle cose già mandate, se ce l'hai ancora
+
+                mSentPtr.Add(new GrblMessage(string.Format("[resume from #{0}]", position + 1), false));
+                Logger.LogMessage("ResumeProgram", "Resume program from #{0}", position + 1);
+
+                GrblCommand.StatePositionBuilder spb = new GrblCommand.StatePositionBuilder();
+
+                if (homing) mQueuePtr.Enqueue(new GrblCommand("$H"));
+
+                if (setwco)
+                {
+                    //compute current point and set offset
+                    GPoint pos = homing ? GPoint.Zero : MachinePosition;
+                    GPoint wco = mTP.LastKnownWCO;
+                    GPoint cur = pos - wco;
+                    mQueue.Enqueue(new GrblCommand(String.Format("G92 X{0} Y{1} Z{2}", cur.X.ToString(System.Globalization.CultureInfo.InvariantCulture), cur.Y.ToString(System.Globalization.CultureInfo.InvariantCulture), cur.Z.ToString(System.Globalization.CultureInfo.InvariantCulture))));
+                }
+
+                for (int i = 0; i < position && i < file.Count; i++) //analizza fino alla posizione
+                    spb.AnalyzeCommand(file[i], false);
+
+                mQueuePtr.Enqueue(new GrblCommand("G90")); //absolute coordinate
+                mQueuePtr.Enqueue(new GrblCommand(string.Format("M5 G0 {0} {1} {2} {3} {4}", spb.X, spb.Y, spb.Z, spb.F, spb.S))); //fast go to the computed position with laser off and set speed and power
+                mQueuePtr.Enqueue(new GrblCommand(spb.GetSettledModals()));
+
+                mTP.JobContinue(LoadedFile, position, mQueuePtr.Count);
+
+                for (int i = position; i < file.Count; i++) //enqueue remaining commands
+                {
+                    if (spb != null) //check the very first movement command and ensure modal MotionMode is settled
+                    {
+                        GrblCommand cmd = file[i].Clone() as GrblCommand;
+                        cmd.BuildHelper();
+                        if (cmd.IsMovement && cmd.G == null)
+                            mQueuePtr.Enqueue(new GrblCommand(spb.MotionMode, cmd));
+                        else
+                            mQueuePtr.Enqueue(cmd);
+                        cmd.DeleteHelper();
+                        spb = null; //only the first time
+                    }
+                    else
+                    {
+                        mQueuePtr.Enqueue(file[i].Clone() as GrblCommand);
+                    }
+                }
+            }
+        }
+
+        public bool HasProgram
+        { get { return file != null && file.Count > 0; } }
+
+        public void EnqueueCommand(GrblCommand cmd)
+        {
+            lock (this)
+            { mQueuePtr.Enqueue(cmd.Clone() as GrblCommand); }
+        }
+
+        public void Configure(ComWrapper.WrapperType wraptype, params object[] conf)
+        {
+            if (wraptype == ComWrapper.WrapperType.UsbSerial && (com == null || com.GetType() != typeof(ComWrapper.UsbSerial)))
+                com = new ComWrapper.UsbSerial();
+            else if (wraptype == ComWrapper.WrapperType.UsbSerial2 && (com == null || com.GetType() != typeof(ComWrapper.UsbSerial2)))
+                com = new ComWrapper.UsbSerial2();
+            else if (wraptype == ComWrapper.WrapperType.Telnet && (com == null || com.GetType() != typeof(ComWrapper.Telnet)))
+                com = new ComWrapper.Telnet();
+            else if (wraptype == ComWrapper.WrapperType.LaserWebESP8266 && (com == null || com.GetType() != typeof(ComWrapper.LaserWebESP8266)))
+                com = new ComWrapper.LaserWebESP8266();
+            else if (wraptype == ComWrapper.WrapperType.Emulator && (com == null || com.GetType() != typeof(ComWrapper.Emulator)))
+                com = new ComWrapper.Emulator();
+
+            com.Configure(conf);
+        }
+
+        public void OpenCom()
+        {
+            try
+            {
+                mAutoBufferSize = DEFAULT_BUFFER_SIZE; //reset to default buffer size
+                SetStatus(MacStatus.Connecting);
+                connectStart = Tools.HiResTimer.TotalMilliseconds;
+
+                if (!com.IsOpen)
+                    com.Open();
+
+                lock (this)
+                {
+                    RX.Start();
+                    TX.Start();
+                }
+            }
+            catch (Exception ex)
+            {
+                Logger.LogMessage("OpenCom", "Error: {0}", ex.Message);
+                SetStatus(MacStatus.Disconnected);
+                com.Close(true);
+                System.Windows.Forms.MessageBox.Show(ex.Message, Strings.BoxConnectErrorTitle, System.Windows.Forms.MessageBoxButtons.OK, System.Windows.Forms.MessageBoxIcon.Error);
+            }
+        }
+
+        public void CloseCom(bool user)
+        {
+            if (mTP.LastIssue == DetectedIssue.Unknown && MachineStatus == MacStatus.Run && InProgram)
+                SetIssue(user ? DetectedIssue.ManualDisconnect : DetectedIssue.UnexpectedDisconnect);
+
+            try
+            {
+                if (com.IsOpen)
+                    com.Close(!user);
+
+                mUsedBuffer = 0;
+                mTP.JobEnd(true);
+
+                TX.Stop();
+                RX.Stop();
+
+                lock (this)
+                { ClearQueue(false); } //non resettare l'elenco delle cose mandate così da non sbiancare la lista
+
+                SetStatus(MacStatus.Disconnected);
+            }
+            catch (Exception ex)
+            {
+                Logger.LogException("CloseCom", ex);
+            }
+        }
+
+        internal void Exiting()
+        {
+            try { CloseCom(true); }
+            catch { }
+
+            try { RX.Stop(); }
+            catch { }
+
+            try { TX.Stop(); }
+            catch { }
+
+            LaserLifeHandler.SaveNow();
+        }
+
+        public bool IsConnected => mMachineStatus != MacStatus.Disconnected && mMachineStatus != MacStatus.Connecting;
+
+        #region Comandi immediati
+
+        public void CycleStartResume(bool auto)
+        {
+            if (CanResumeHold)
+            {
+                mHoldByCoolingRequest = mHoldByUserRequest = false;
+                SendImmediate(126);
+            }
+        }
+
+        public void FeedHold(bool cooling)
+        {
+            if (CanFeedHold)
+            {
+                mHoldByUserRequest = !cooling;
+                mHoldByCoolingRequest = cooling;
+                SendImmediate(33);
+            }
+        }
+
+        public void SafetyDoor()
+        { SendImmediate(64); }
+
+        // GRBL & smoothie : Send "?" to retrieve position
+        // MarlinCore : Override : Send "M114\n"
+        protected virtual void QueryPosition()
+        { SendImmediate(63, true); }
+
+        public void GrblReset() //da comando manuale esterno (pulsante)
+        {
+            if (CanResetGrbl)
+            {
+                if (mTP.LastIssue == DetectedIssue.Unknown && MachineStatus == MacStatus.Run && InProgram)
+                    SetIssue(DetectedIssue.ManualReset);
+                InternalReset(true);
+            }
+        }
+
+        private void InternalReset(bool device)
+        {
+            lock (this)
+            {
+                ClearQueue(true);
+                mUsedBuffer = 0;
+                mTP.JobEnd(true);
+                mCurOvLinear = mCurOvRapids = mCurOvPower = 100;
+                mTarOvLinear = mTarOvRapids = mTarOvPower = 100;
+
+                if (device) SendBoardResetCommand();
+            }
+            RiseOverrideChanged();
+        }
+
+        protected virtual void SendBoardResetCommand()
+        {
+            SendImmediate(24);
+        }
+
+        public virtual void SendImmediate(byte b, bool mute = false)
+        {
+            try
+            {
+                if (!mute) Logger.LogMessage("SendImmediate", "Send Immediate Command [0x{0:X}]", b);
+
+                lock (this)
+                { if (com.IsOpen) com.Write(b); }
+            }
+            catch (Exception ex)
+            { Logger.LogException("SendImmediate", ex); }
+        }
+
+        #endregion
+
+        #region Public Property
+
+        public int ProgramTarget
+        { get { return mTP.Target; } }
+
+        public int ProgramSent
+        { get { return mTP.Sent; } }
+
+        public int ProgramExecuted
+        { get { return mTP.Executed; } }
+
+        public TimeSpan ProgramTime
+        { get { return mTP.TotalJobTime; } }
+
+        public TimeSpan ProgramGlobalTime
+        { get { return mTP.TotalGlobalJobTime; } }
+
+        public TimeSpan ProjectedTime
+        { get { return mTP.ProjectedTarget; } }
+
+        public MacStatus MachineStatus
+        { get { return mMachineStatus; } }
+
+        public bool InProgram
+        { get { return mTP.InProgram; } }
+
+        public GPoint MachinePosition
+        { get { return mMPos; } }
+
+        public GPoint WorkPosition //WCO = MPos - WPos
+        { get { return mMPos - mWCO; } }
+
+        public GPoint WorkingOffset
+        { get { return mWCO; } }
+
+        public int Executed
+        { get { return mSent.Count; } }
+
+        public List<IGrblRow> SentCommand(int index, int count)
+        {
+            index = Math.Min(index, mSent.Count - 1);       //force index to be in range
+            count = Math.Min(count, mSent.Count - index);   //force count to be in range
+
+            if (index >= 0 && count > 0)
+                return mSent.GetRange(index, count);
+            else
+                return new System.Collections.Generic.List<IGrblRow>();
+        }
+        #endregion
+
+        #region Grbl Version Support
+
+        public bool SupportRTO
+        { get { return GrblVersion != null && GrblVersion >= new GrblVersionInfo(1, 1); } }
+
+        public virtual bool SupportTrueJogging
+        { get { return GrblVersion != null && GrblVersion >= new GrblVersionInfo(1, 1); } }
+
+        public bool SupportCSV
+        { get { return GrblVersion != null && GrblVersion >= new GrblVersionInfo(1, 1); } }
+
+        public bool SupportOverride
+        { get { return GrblVersion != null && GrblVersion >= new GrblVersionInfo(1, 1); } }
+
+        public bool SupportLaserMode
+        { get { return GrblVersion != null && GrblVersion >= new GrblVersionInfo(1, 1); } }
+
+        #endregion
+
+        public bool JogEnabled
+        {
+            get
+            {
+                if (SupportTrueJogging)
+                    return IsConnected && (MachineStatus == GrblCore.MacStatus.Idle || MachineStatus == GrblCore.MacStatus.Jog);
+                else
+                    return IsConnected && (MachineStatus == GrblCore.MacStatus.Idle || MachineStatus == GrblCore.MacStatus.Run) && !InProgram;
+            }
+        }
+
+        internal void EnqueueZJog(JogDirection dir, decimal step, bool fast)
+        {
+            if (JogEnabled)
+            {
+                mPrenotedJogSpeed = (fast ? 100000 : JogSpeed);
+
+                if (SupportTrueJogging)
+                    DoJogV11(dir, step);
+                else
+                    EmulateJogV09(dir, step); //immediato
+            }
+        }
+
+        public void BeginJog(PointF target, bool fast)
+        {
+            if (JogEnabled)
+            {
+                mPrenotedJogSpeed = (fast ? 100000 : JogSpeed);
+                target = LimitToBound(target);
+
+                if (SupportTrueJogging)
+                    DoJogV11(target);
+                else
+                    EmulateJogV09(target);
+            }
+        }
+
+        private PointF LimitToBound(PointF target)
+        {
+            if (Configuration.SoftLimit)
+            {
+                GPoint p = mWCO;
+                PointF rv = new PointF(Math.Min(Math.Max(target.X, -mWCO.X), (float)Configuration.TableWidth - mWCO.X), Math.Min(Math.Max(target.Y, -mWCO.Y), (float)Configuration.TableHeight - mWCO.Y));
+                return rv;
+            }
+
+            return target;
+        }
+
+        public void BeginJog(JogDirection dir, bool fast) //da chiamare su ButtonDown
+        {
+            if (JogEnabled)
+            {
+                mPrenotedJogSpeed = (fast ? 100000 : JogSpeed);
+
+                if (SupportTrueJogging)
+                    DoJogV11(dir, JogStep);
+                else
+                    EmulateJogV09(dir, JogStep);
+            }
+        }
+
+        private void EmulateJogV09(JogDirection dir, decimal step) //emulate jog using plane G-Code
+        {
+            if (dir == JogDirection.Home)
+            {
+                EnqueueCommand(new GrblCommand(string.Format("G90")));
+                EnqueueCommand(new GrblCommand(string.Format("G0X0Y0F{0}", mPrenotedJogSpeed)));
+            }
+            else
+            {
+                string cmd = "G0";
+
+                if (dir == JogDirection.NE || dir == JogDirection.E || dir == JogDirection.SE)
+                    cmd += $"X{step.ToString("0.0", NumberFormatInfo.InvariantInfo)}";
+                if (dir == JogDirection.NW || dir == JogDirection.W || dir == JogDirection.SW)
+                    cmd += $"X-{step.ToString("0.0", NumberFormatInfo.InvariantInfo)}";
+                if (dir == JogDirection.NW || dir == JogDirection.N || dir == JogDirection.NE)
+                    cmd += $"Y{step.ToString("0.0", NumberFormatInfo.InvariantInfo)}";
+                if (dir == JogDirection.SW || dir == JogDirection.S || dir == JogDirection.SE)
+                    cmd += $"Y-{step.ToString("0.0", NumberFormatInfo.InvariantInfo)}";
+                if (dir == JogDirection.Zdown)
+                    cmd += $"Z-{step.ToString("0.0", NumberFormatInfo.InvariantInfo)}";
+                if (dir == JogDirection.Zup)
+                    cmd += $"Z{step.ToString("0.0", NumberFormatInfo.InvariantInfo)}";
+
+                cmd += $"F{mPrenotedJogSpeed}";
+
+                EnqueueCommand(new GrblCommand("G91"));
+                EnqueueCommand(new GrblCommand(cmd));
+                EnqueueCommand(new GrblCommand("G90"));
+            }
+        }
+
+        private void EmulateJogV09(PointF target) //emulate jog using plane G-Code
+        {
+            string cmd = "G0";
+
+            cmd += $"X{target.X.ToString("0.00", NumberFormatInfo.InvariantInfo)}";
+            cmd += $"Y{target.Y.ToString("0.00", NumberFormatInfo.InvariantInfo)}";
+            cmd += $"F{mPrenotedJogSpeed}";
+
+            EnqueueCommand(new GrblCommand("G90"));
+            EnqueueCommand(new GrblCommand(cmd));
+        }
+
+        private void DoJogV11(JogDirection dir, decimal step)
+        {
+            if (ContinuosJogEnabled && dir != JogDirection.Zdown && dir != JogDirection.Zup) //se C.J. e non Z => prenotato
+            {
+                mPrenotedJogDirection = dir;
+                //lo step è quello configurato
+            }
+            else //non è CJ o non è Z => immediate enqueue jog command
+            {
+                mPrenotedJogDirection = JogDirection.None;
+                if (dir == JogDirection.Home)
+                    EnqueueCommand(new GrblCommand(string.Format("$J=G90X0Y0F{0}", mPrenotedJogSpeed)));
+                else
+                    EnqueueCommand(GetRelativeJogCommandv11(dir, step));
+            }
+        }
+
+        private void DoJogV11(PointF target)
+        {
+            mPrenotedJogDirection = JogDirection.None;
+            SendImmediate(0x85); //abort previous jog
+            EnqueueCommand(new GrblCommand(string.Format("$J=G90X{0}Y{1}F{2}", target.X.ToString("0.00", NumberFormatInfo.InvariantInfo), target.Y.ToString("0.00", NumberFormatInfo.InvariantInfo), mPrenotedJogSpeed)));
+        }
+
+        private GrblCommand GetRelativeJogCommandv11(JogDirection dir, decimal step)
+        {
+            string cmd = "$J=G91";
+            if (dir == JogDirection.NE || dir == JogDirection.E || dir == JogDirection.SE)
+                cmd += $"X{step.ToString("0.0", NumberFormatInfo.InvariantInfo)}";
+            if (dir == JogDirection.NW || dir == JogDirection.W || dir == JogDirection.SW)
+                cmd += $"X-{step.ToString("0.0", NumberFormatInfo.InvariantInfo)}";
+            if (dir == JogDirection.NW || dir == JogDirection.N || dir == JogDirection.NE)
+                cmd += $"Y{step.ToString("0.0", NumberFormatInfo.InvariantInfo)}";
+            if (dir == JogDirection.SW || dir == JogDirection.S || dir == JogDirection.SE)
+                cmd += $"Y-{step.ToString("0.0", NumberFormatInfo.InvariantInfo)}";
+            if (dir == JogDirection.Zdown)
+                cmd += $"Z-{step.ToString("0.0", NumberFormatInfo.InvariantInfo)}";
+            if (dir == JogDirection.Zup)
+                cmd += $"Z{step.ToString("0.0", NumberFormatInfo.InvariantInfo)}";
+
+            cmd += $"F{mPrenotedJogSpeed}";
+            return new GrblCommand(cmd);
+        }
+
+        private GrblCommand GetContinuosJogCommandv11(JogDirection dir)
+        {
+            string cmd = "$J=G53";
+            if (dir == JogDirection.NE || dir == JogDirection.E || dir == JogDirection.SE)
+                cmd += $"X{Configuration.TableWidth.ToString("0.0", NumberFormatInfo.InvariantInfo)}";
+            if (dir == JogDirection.NW || dir == JogDirection.W || dir == JogDirection.SW)
+                cmd += $"X{0.ToString("0.0", NumberFormatInfo.InvariantInfo)}";
+            if (dir == JogDirection.NW || dir == JogDirection.N || dir == JogDirection.NE)
+                cmd += $"Y{Configuration.TableHeight.ToString("0.0", NumberFormatInfo.InvariantInfo)}";
+            if (dir == JogDirection.SW || dir == JogDirection.S || dir == JogDirection.SE)
+                cmd += $"Y{0.ToString("0.0", NumberFormatInfo.InvariantInfo)}";
+            cmd += $"F{mPrenotedJogSpeed}";
+            return new GrblCommand(cmd);
+        }
+
+        public void EndJogV11() //da chiamare su ButtonUp
+        {
+            mPrenotedJogDirection = JogDirection.Abort;
+        }
+
+        private void PushJogCommand()
+        {
+            if (SupportTrueJogging && mPrenotedJogDirection != JogDirection.None && mPending.Count == 0)
+            {
+                if (mPrenotedJogDirection == JogDirection.Abort)
+                {
+                    if (ContinuosJogEnabled)
+                        SendImmediate(0x85);
+                }
+                else if (mPrenotedJogDirection == JogDirection.Home)
+                {
+                    EnqueueCommand(new GrblCommand(string.Format("$J=G90X0Y0F{0}", mPrenotedJogSpeed)));
+                }
+                else
+                {
+                    if (ContinuosJogEnabled)
+                        EnqueueCommand(GetContinuosJogCommandv11(mPrenotedJogDirection));
+                    else
+                        EnqueueCommand(GetRelativeJogCommandv11(mPrenotedJogDirection, JogStep));
+                }
+
+                mPrenotedJogDirection = JogDirection.None;
+            }
+        }
+
+
+        private void StartTX()
+        {
+            lock (this)
+            {
+                // No soft reset when opening COM port for smoothieware
+                if (Type != Firmware.Smoothie)
+                    InternalReset(Settings.GetObject("Reset Grbl On Connect", true));
+
+                InitializeBoard();
+                QueryTimer.Start();
+            }
+        }
+
+        protected virtual void InitializeBoard()
+        {
+            QueryPosition();
+        }
+
+        protected void ThreadTX()
+        {
+            lock (this)
+            {
+                try
+                {
+                    if (MachineStatus == MacStatus.Connecting && Tools.HiResTimer.TotalMilliseconds - connectStart > 10000)
+                        OnConnectTimeout();
+
+                    if (!TX.MustExitTH())
+                    {
+                        PushJogCommand();
+
+                        if (CanSend())
+                            SendLine();
+
+                        ManageCoolingCycles();
+                    }
+
+                    if (QueryTimer.Expired)
+                        QueryPosition();
+
+                    DetectHang();
+
+                    TX.SleepTime = CanSend() ? CurrentThreadingMode.TxShort : CurrentThreadingMode.TxLong;
+                    QueryTimer.Period = TimeSpan.FromMilliseconds(CurrentThreadingMode.StatusQuery);
+                }
+                catch (Exception ex)
+                { Logger.LogException("ThreadTX", ex); }
+            }
+        }
+
+        // Override by Marlin
+        protected virtual void DetectHang()
+        {
+            if (mTP.LastIssue == DetectedIssue.Unknown && MachineStatus == MacStatus.Run && InProgram)
+            {
+                //bool executingM4 = false;
+                //if (HasPendingCommand())
+                //{
+                //	GrblCommand cur = mPending.Peek();
+                //	cur.BuildHelper();
+                //	executingM4 = cur.IsPause;
+                //	cur.DeleteHelper();
+                //}
+
+                bool noQueryResponse = debugLastStatusDelay.ElapsedTime > TimeSpan.FromTicks(QueryTimer.Period.Ticks * 10) && debugLastStatusDelay.ElapsedTime > TimeSpan.FromSeconds(5);
+                //bool noMovement = !executingM4 && debugLastMoveDelay.ElapsedTime > TimeSpan.FromSeconds(10);
+
+                if (noQueryResponse)
+                    SetIssue(DetectedIssue.StopResponding);
+
+                //else if (noMovement)
+                //	SetIssue(DetectedIssue.StopMoving);
+            }
+        }
+
+
+        private void OnConnectTimeout()
+        {
+            if (com.IsOpen)
+            {
+                Logger.LogMessage("OpenCom", "Connection timeout!");
+                com.Close(true); //this cause disconnection from RX thread ("ReadLineOrDisconnect")
+            }
+        }
+
+        private bool CanSend()
+        {
+            GrblCommand next = PeekNextCommand();
+            return next != null && HasSpaceInBuffer(next);
+        }
+
+        private bool BufferIsFull()
+        {
+            GrblCommand next = PeekNextCommand();
+            return mUsedBuffer > 0 && next != null && !HasSpaceInBuffer(next);
+        }
+
+        private GrblCommand PeekNextCommand()
+        {
+            if (HasPendingCommands() && mPending.Peek().IsWriteEEPROM) //if managing eeprom write act like sync
+                return null;
+            else if (CurrentStreamingMode == StreamingMode.Buffered && mQueuePtr.Count > 0) //sono buffered e ho roba da trasmettere
+                return mQueuePtr.Peek();
+            else if (CurrentStreamingMode != StreamingMode.Buffered && mPending.Count == 0) //sono sync e sono vuoto
+                if (mRetryQueue != null) return mRetryQueue;
+                else if (mQueuePtr.Count > 0) return mQueuePtr.Peek();
+                else return null;
+            else
+                return null;
+        }
+
+        private void RemoveManagedCommand()
+        {
+            if (mRetryQueue != null)
+                mRetryQueue = null;
+            else
+                mQueuePtr.Dequeue();
+        }
+
+        protected virtual bool HasSpaceInBuffer(GrblCommand command)
+        { return (mUsedBuffer + command.SerialData.Length) <= BufferSize; }
+
+        private void SendLine()
+        {
+            GrblCommand tosend = PeekNextCommand();
+            if (tosend != null)
+            {
+                try
+                {
+                    tosend.BuildHelper();
+
+                    tosend.SetSending();
+                    mSentPtr.Add(tosend);
+                    mPending.Enqueue(tosend);
+                    RemoveManagedCommand();
+
+                    SendToSerial(tosend);
+
+                    if (mTP.InProgram)
+                        mTP.JobSent();
+
+                    debugLastMoveOrActivityDelay.Start();
+                }
+                catch (Exception ex)
+                {
+                    if (tosend != null) Logger.LogMessage("SendLine", "Error sending [{0}] command: {1}", tosend.Command, ex.Message);
+                    //Logger.LogException("SendLine", ex);
+                }
+                finally { tosend.DeleteHelper(); }
+            }
+        }
+
+        protected virtual void SendToSerial(GrblCommand tosend)
+        {
+            mUsedBuffer += tosend.SerialData.Length;
+            com.Write(tosend.SerialData); //invio dei dati alla linea di comunicazione
+        }
+
+        public int UsedBuffer
+        { get { return mUsedBuffer; } }
+
+        public int FreeBuffer
+        { get { return BufferSize - mUsedBuffer; } }
+
+        public virtual int BufferSize
+        { get { return mAutoBufferSize; } }
+
+        public int GrblBlock
+        { get { return mGrblBlocks; } }
+
+        public int GrblBuffer
+        { get { return mGrblBuffer; } }
+
+        void ThreadRX()
+        {
+            try
+            {
+                string rline = null;
+                if ((rline = WaitComLineOrDisconnect()) != null)
+                {
+                    lock (this)
+                    {
+                        ManageReceivedLine(rline);
+                        HandleMissingOK();
+                    }
+                }
+
+                RX.SleepTime = HasIncomingData() ? CurrentThreadingMode.RxShort : CurrentThreadingMode.RxLong;
+            }
+            catch (Exception ex)
+            { Logger.LogException("ThreadRX", ex); }
+        }
+
+        // this function try to detect and automatically unlock from a "buffer stuck" condition
+        // a "buffer stuck" condition occurs when LaserGRBL does not receive some "ok's" 
+        // back from grbl (i.e. because of electrical noise on wire) and so LaserGRBL
+        // does no longer send commands anymore because think the buffer is full
+        // this feature can work only if $10=3 (status report with buffer size report enabled)
+        private void HandleMissingOK()
+        {
+            if (IsBufferStuck() && MachineSayBufferFree())
+                UnlockFromBufferStuck(true);
+        }
+
+        public void UnlockFromBufferStuck(bool auto)
+        {
+            if (IsBufferStuck())
+                CreateFakeOK(mPending.Count, auto); //rispondi "ok" a tutti i comandi pending
+        }
+
+        public bool IsBufferStuck()
+        {
+            return MachineStatus == MacStatus.Run && HasPendingCommands() && !BufferIsFree() && MachineNotMovingOrReply();
+        }
+
+        private void CreateFakeOK(int count, bool auto)
+        {
+            mSentPtr.Add(new GrblMessage("Unlock from buffer stuck!", false));
+            string act = auto ? "auto" : "manual";
+
+            ComWrapper.ComLogger.Log("com", $"Handle Missing OK [{count}] ({act})");
+            Logger.LogMessage("Issue detector", $"Handle Missing OK [{count}] ({act})");
+
+            for (int i = 0; i < count; i++)
+                ManageCommandResponse("ok");
+        }
+
+        private bool MachineNotMovingOrReply() => debugLastMoveOrActivityDelay.ElapsedTime > TimeSpan.FromSeconds(10);
+        private bool MachineSayBufferFree() => mGrblBuffer == BufferSize;
+        private bool BufferIsFree() => mUsedBuffer == 0;
+        private bool HasPendingCommands() => mPending.Count > 0;
+
+        protected virtual void ManageReceivedLine(string rline)
+        {
+            if (IsCommandReplyMessage(rline))
+                ManageCommandResponse(rline);
+            else if (IsRealtimeStatusMessage(rline))
+                ManageRealTimeStatus(rline);
+            else if (IsGrblHalWelcomeMessage(rline))
+                ManageGrblHalWelcomeMessage(rline);
+            else if (IsVigoWelcomeMessage(rline))
+                ManageVigoWelcomeMessage(rline);
+            else if (IsOrturModelMessage(rline))
+                ManageOrturModelMessage(rline);
+            else if (IsAuferoModelMessage(rline))
+                ManageOrturModelMessage(rline);
+            else if (IsOrturFirmwareMessage(rline))
+                ManageOrturFirmwareMessage(rline);
+            else if (IsStandardWelcomeMessage(rline))
+                ManageStandardWelcomeMessage(rline);
+            else if (IsBrokenOkMessage(rline))
+                ManageBrokenOkMessage(rline);
+            else if (IsStandardBlockingAlarm(rline))
+                ManageStandardBlockingAlarm(rline);
+            else if (IsStaIPMessage(rline))
+                ManageStaIPMessage(rline);
+            //else if (IsOrturBlockingAlarm(rline))
+            //	ManageOrturBlockingAlarm(rline);
+            else
+                ManageGenericMessage(rline);
+        }
+
+        private void ManageStaIPMessage(string rline)
+        {
+            try
+            {
+                //[MSG:Get IP 192.168.1.182]
+                mDetectedIP = rline.Substring(12, rline.Length - 1 - 12);
+                ManageGenericMessage(rline); //process as usual
+            }
+            catch (Exception ex)
+            {
+                Logger.LogMessage("IP Detector", "Ex on [{0}] message", rline);
+                Logger.LogException("IP Detector", ex);
+            }
+        }
+
+        private bool IsCommandReplyMessage(string rline) => rline.ToLower().StartsWith("ok") || rline.ToLower().StartsWith("error");
+        private bool IsRealtimeStatusMessage(string rline) => rline.StartsWith("<") && rline.EndsWith(">");
+        private bool IsGrblHalWelcomeMessage(string rline) => rline.StartsWith("GrblHAL");
+        private bool IsVigoWelcomeMessage(string rline) => rline.StartsWith("Grbl-Vigo");
+        private bool IsOrturModelMessage(string rline) => rline.StartsWith("Ortur ");
+        private bool IsAuferoModelMessage(string rline) => rline.StartsWith("Aufero ");
+        private bool IsOrturFirmwareMessage(string rline) => rline.StartsWith("OLF");
+        private bool IsStandardWelcomeMessage(string rline) => rline.StartsWith("Grbl");
+        private bool IsBrokenOkMessage(string rline) => rline.ToLower().Contains("ok");
+        private bool IsStandardBlockingAlarm(string rline) => rline.ToLower().StartsWith("alarm:");
+        private bool IsIVerMessage(string rline) => rline.StartsWith("[VER:") && rline.EndsWith("]");
+        private bool IsIOptMessage(string rline) => rline.StartsWith("[OPT:") && rline.EndsWith("]");
+        private bool IsStaIPMessage(string rline) => rline.StartsWith("[MSG:Get IP ") && rline.EndsWith("]");
+        private bool IsOrturBlockingAlarm(string rline) => false;
+
+        private void ManageGenericMessage(string rline)
+        {
+            try { mSentPtr.Add(new GrblMessage(rline, SupportCSV)); }
+            catch (Exception ex)
+            {
+                Logger.LogMessage("GenericMessage", "Ex on [{0}] message", rline);
+                Logger.LogException("GenericMessage", ex);
+            }
+        }
+
+        private void ManageStandardBlockingAlarm(string rline)
+        {
+            if (mTP.LastIssue == DetectedIssue.Unknown && InProgram)
+                SetIssue(DetectedIssue.MachineAlarm);
+
+            ManageGenericMessage(rline); //process as usual
+        }
+
+        private void ManageOrturBlockingAlarm(string rline)
+        {
+            ManageGenericMessage(rline); //process as usual
+        }
+
+        private void ManageStandardWelcomeMessage(string rline)
+        {
+            //Grbl X.Xx ['$' for help]
+            try
+            {
+                int maj = int.Parse(rline.Substring(5, 1));
+                int min = int.Parse(rline.Substring(7, 1));
+                char build = rline.Substring(8, 1).ToCharArray()[0];
+                GrblVersion = new GrblVersionInfo(maj, min, build, mWelcomeSeen, mVersionSeen, false);
+
+                DetectUnexpectedReset();
+                OnStartupMessage();
+            }
+            catch (Exception ex)
+            {
+                Logger.LogMessage("VersionInfo", "Ex on [{0}] message", rline);
+                Logger.LogException("VersionInfo", ex);
+            }
+            mSentPtr.Add(new GrblMessage(rline, false));
+        }
+
+        private void ManageGrblHalWelcomeMessage(string rline)
+        {
+            //GrblHAL X.Xx ['$' or '$HELP' for help]
+            try
+            {
+                int maj = int.Parse(rline.Substring(8, 1));
+                int min = int.Parse(rline.Substring(10, 1));
+                char build = rline.Substring(11, 1).ToCharArray()[0];
+                GrblVersion = new GrblVersionInfo(maj, min, build, mWelcomeSeen, mVersionSeen, true);
+
+                DetectUnexpectedReset();
+                OnStartupMessage();
+            }
+            catch (Exception ex)
+            {
+                Logger.LogMessage("VersionInfo", "Ex on [{0}] message", rline);
+                Logger.LogException("VersionInfo", ex);
+            }
+            mSentPtr.Add(new GrblMessage(rline, false));
+        }
+
+        private void ManageVigoWelcomeMessage(string rline)
+        {
+            //Grbl-Vigo:1.1f|Build:G-20170131-V3.0-20200720
+            try
+            {
+                int maj = int.Parse(rline.Substring(10, 1));
+                int min = int.Parse(rline.Substring(12, 1));
+                char build = rline.Substring(13, 1).ToCharArray()[0];
+                string VendorVersion = rline.Split(':')[2];
+                GrblVersion = new GrblVersionInfo(maj, min, build, "Vigotec", VendorVersion, false);
+                Logger.LogMessage("VigoInfo", "Detected {0}", VendorVersion);
+
+                DetectUnexpectedReset();
+                OnStartupMessage();
+            }
+            catch (Exception ex)
+            {
+                Logger.LogMessage("VersionInfo", "Ex on [{0}] message", rline);
+                Logger.LogException("VersionInfo", ex);
+            }
+            mSentPtr.Add(new GrblMessage(rline, false));
+        }
+
+        private void ManageOrturModelMessage(string rline)
+        {
+            try
+            {
+                mWelcomeSeen = rline;
+                mWelcomeSeen = mWelcomeSeen.Replace("Ready", "");
+                mWelcomeSeen = mWelcomeSeen.Replace("!", "");
+                mWelcomeSeen = mWelcomeSeen.Trim();
+                Logger.LogMessage("OrturInfo", "Detected {0}", mWelcomeSeen);
+            }
+            catch (Exception ex)
+            {
+                Logger.LogMessage("OrturInfo", "Ex on [{0}] message", rline);
+                Logger.LogException("OrturInfo", ex);
+            }
+            mSentPtr.Add(new GrblMessage(rline, false));
+        }
+
+        private void ManageOrturFirmwareMessage(string rline)
+        {
+            try
+            {
+                mVersionSeen = rline;
+                mVersionSeen = mVersionSeen.Replace("OLF", "");
+                mVersionSeen = mVersionSeen.Trim(new char[] { '.', ' ', ':' });
+                Logger.LogMessage("OrturInfo", "Detected OLF {0}", mVersionSeen);
+            }
+            catch (Exception ex)
+            {
+                Logger.LogMessage("OrturInfo", "Ex on [{0}] message", rline);
+                Logger.LogException("OrturInfo", ex);
+            }
+            mSentPtr.Add(new GrblMessage(rline, false));
+        }
+
+        private void OnStartupMessage() //resetta tutto, così funziona anche nel caso di hard-unexpected reset
+        {
+            lock (this)
+            {
+                ClearQueue(false);
+                mUsedBuffer = 0;
+                mTP.JobEnd(true);
+                mCurOvLinear = mCurOvRapids = mCurOvPower = 100;
+                mTarOvLinear = mTarOvRapids = mTarOvPower = 100;
+            }
+            RiseOverrideChanged();
+        }
+
+        private void DetectUnexpectedReset()
+        {
+            if (mTP.LastIssue == DetectedIssue.Unknown && MachineStatus == MacStatus.Run && InProgram)
+                SetIssue(DetectedIssue.UnexpectedReset);
+        }
+
+        private GrblVersionInfo StatusReportVersion(string rline)
+        {
+            //if version is known -> return version
+            if (GrblVersion != null)
+                return GrblVersion;
+
+            //else guess from rline
+            //the check of Pin: is due to compatibility with 1.0c https://github.com/arkypita/LaserGRBL/issues/317
+            if (rline.Contains("|") && !rline.Contains("Pin:"))
+                return new GrblVersionInfo(1, 1);
+            else if (rline.Contains("|") && rline.Contains("Pin:"))
+                return new GrblVersionInfo(1, 0, 'c');
+            else
+                return new GrblVersionInfo(0, 9);
+        }
+
+        private void ManageRealTimeStatus(string rline)
+        {
+            try
+            {
+                debugLastStatusDelay.Start();
+
+                rline = rline.Substring(1, rline.Length - 2);
+
+                GrblVersionInfo rversion = StatusReportVersion(rline);
+                if (rversion >= new GrblVersionInfo(1, 1))
+                {
+                    //grbl > 1.1 - https://github.com/gnea/grbl/wiki/Grbl-v1.1-Interface#real-time-status-reports
+                    string[] arr = rline.Split("|".ToCharArray());
+
+                    ParseMachineStatus(arr[0]);
+
+                    for (int i = 1; i < arr.Length; i++)
+                    {
+                        if (arr[i].StartsWith("Ov:"))
+                            ParseOverrides(arr[i]);
+                        else if (arr[i].StartsWith("Bf:"))
+                            ParseBf(arr[i]);
+                        else if (arr[i].StartsWith("WPos:"))
+                            ParseWPos(arr[i]);
+                        else if (arr[i].StartsWith("MPos:"))
+                            ParseMPos(arr[i]);
+                        else if (arr[i].StartsWith("WCO:"))
+                            ParseWCO(arr[i]);
+                        else if (arr[i].StartsWith("FS:"))
+                            ParseFS(arr[i]);
+                        else if (arr[i].StartsWith("F:"))
+                            ParseF(arr[i]);
+                    }
+                }
+                else //<Idle,MPos:0.000,0.000,0.000,WPos:0.000,0.000,0.000>
+                {
+                    string[] arr = rline.Split(",".ToCharArray());
+
+                    if (arr.Length > 0)
+                        ParseMachineStatus(arr[0]);
+                    if (arr.Length > 3)
+                        SetMPosition(new GPoint(float.Parse(arr[1].Substring(5, arr[1].Length - 5), System.Globalization.NumberFormatInfo.InvariantInfo), float.Parse(arr[2], System.Globalization.NumberFormatInfo.InvariantInfo), float.Parse(arr[3], System.Globalization.NumberFormatInfo.InvariantInfo)));
+                    if (arr.Length > 6)
+                        ComputeWCO(new GPoint(float.Parse(arr[4].Substring(5, arr[4].Length - 5), System.Globalization.NumberFormatInfo.InvariantInfo), float.Parse(arr[5], System.Globalization.NumberFormatInfo.InvariantInfo), float.Parse(arr[6], System.Globalization.NumberFormatInfo.InvariantInfo)));
+                }
+            }
+            catch (Exception ex)
+            {
+                Logger.LogMessage("RealTimeStatus", "Ex on [{0}] message", rline);
+                Logger.LogException("RealTimeStatus", ex);
+            }
+        }
+
+        private void ComputeWCO(GPoint wpos) //WCO = MPos - WPos
+        {
+            SetWCO(mMPos - wpos);
+        }
+
+        private void ParseWCO(string p)
+        {
+            string wco = p.Substring(4, p.Length - 4);
+            string[] xyz = wco.Split(",".ToCharArray());
+            SetWCO(new GPoint(ParseFloat(xyz, 0), ParseFloat(xyz, 1), ParseFloat(xyz, 2)));
+        }
+
+        private void ParseWPos(string p)
+        {
+            string wpos = p.Substring(5, p.Length - 5);
+            string[] xyz = wpos.Split(",".ToCharArray());
+            SetMPosition(mWCO + new GPoint(ParseFloat(xyz, 0), ParseFloat(xyz, 1), ParseFloat(xyz, 2)));
+        }
+
+        private void ParseMPos(string p)
+        {
+            string mpos = p.Substring(5, p.Length - 5);
+            string[] xyz = mpos.Split(",".ToCharArray());
+            SetMPosition(new GPoint(ParseFloat(xyz, 0), ParseFloat(xyz, 1), ParseFloat(xyz, 2)));
+        }
+
+        protected static float ParseFloat(string value)
+        {
+            return float.Parse(value, NumberFormatInfo.InvariantInfo);
+        }
+
+        protected static float ParseFloat(string[] arr, int idx, float defval = 0.0f)
+        {
+            if (arr == null || idx < 0 || idx >= arr.Length) return defval;
+            return float.Parse(arr[idx], NumberFormatInfo.InvariantInfo);
+        }
+
+        private void ParseBf(string p)
+        {
+            string bf = p.Substring(3, p.Length - 3);
+            string[] ab = bf.Split(",".ToCharArray());
+
+            mGrblBlocks = int.Parse(ab[0]);
+            mGrblBuffer = int.Parse(ab[1]);
+
+            EnlargeBuffer(mGrblBuffer, false); //do not force here, we cannot rely on values received from report (electrical noise?!)
+        }
+
+        private void EnlargeBuffer(int newval, bool force)
+        {
+            int oldval = mAutoBufferSize;
+
+            if (force) //this came from $I at connect, and so it is a verified buffer size
+            {
+                mAutoBufferSize = newval;
+            }
+            else if (mAutoBufferSize == DEFAULT_BUFFER_SIZE)
+            {
+                // act only to change default value at first event
+                // do not re-act without a new connect
+                // only allow known values (do not accept error in bf message caused by electrical noise)
+
+                if (newval == 128) //Grbl v1.1 with enabled buffer report
+                    mAutoBufferSize = 128;
+                else if (newval == 255) //Grbl-Mega fixed
+                    mAutoBufferSize = 255;
+                else if (newval == 256) //Grbl-Mega
+                    mAutoBufferSize = 256;
+                else if (newval == 10240) //Grbl-LPC
+                    mAutoBufferSize = 10240;
+                else if (newval == 254) //Ortur
+                    mAutoBufferSize = 254;
+            }
+
+            if (mAutoBufferSize != oldval)
+                Logger.LogMessage("EnlargeBuffer", "Buffer size changed to {0} [{1}]", mAutoBufferSize, force);
+        }
+
+        private void ParseFS(string p)
+        {
+            string sfs = p.Substring(3, p.Length - 3);
+            string[] fs = sfs.Split(",".ToCharArray());
+            SetFS(ParseFloat(fs, 0), ParseFloat(fs, 1));
+        }
+
+        protected virtual void ParseF(string p)
+        {
+            string f = p.Substring(2, p.Length - 2);
+            SetFS(ParseFloat(f), 0);
+        }
+
+        protected void SetFS(float f, float s)
+        {
+            LaserLifeHandler.ComputeLaserTrueTime(mCurS);
+            mCurF = f;
+            mCurS = s;
+        }
+
+
+        protected void SetMPosition(GPoint pos)
+        {
+            if (pos != mMPos)
+            {
+                mMPos = pos;
+                debugLastMoveOrActivityDelay.Start();
+            }
+        }
+
+        private void SetWCO(GPoint wco)
+        {
+            mWCO = wco;
+            mTP.LastKnownWCO = wco; //remember last wco for job resume
+        }
+
+
+        protected void ManageBrokenOkMessage(string rline) //
+        {
+            mSentPtr.Add(new GrblMessage("Handle broken ok!", false));
+            Logger.LogMessage("CommandResponse", "Broken \"ok\" message: [{0}]", rline);
+            ManageCommandResponse("ok");
+        }
+
+        protected void ManageCommandResponse(string rline)
+        {
+            try
+            {
+                debugLastMoveOrActivityDelay.Start(); //add a reset to prevent HangDetector trigger on G4
+                if (HasPendingCommands())
+                {
+                    GrblCommand pending = mPending.Peek();  //necessario fare peek
+                    pending.SetResult(rline, SupportCSV);   //assegnare lo stato
+                    mPending.Dequeue();                     //solo alla fine rimuoverlo dalla lista (per write config che si aspetta che lo stato sia noto non appena la coda si svuota)
+
+                    mUsedBuffer = Math.Max(0, mUsedBuffer - pending.SerialData.Length);
+
+                    if (mTP.InProgram && pending.RepeatCount == 0) //solo se non è una ripetizione aggiorna il tempo
+                        mTP.JobExecuted(pending.TimeOffset);
+
+                    if (mTP.InProgram && pending.Status == GrblCommand.CommandStatus.ResponseBad)
+                        mTP.JobError(); //incrementa il contatore
+
+                    if (pending.IsWriteEEPROM && pending.Status == GrblCommand.CommandStatus.ResponseGood)
+                        Configuration.AddOrUpdate(pending.GetDecodedMessage());
+
+                    //ripeti errori programma && non ho una coda (magari mi sto allineando per cambio conf buff/sync) && ho un errore && non l'ho già ripetuto troppe volte
+                    if (InProgram && CurrentStreamingMode == StreamingMode.RepeatOnError && mPending.Count == 0 && pending.Status == GrblCommand.CommandStatus.ResponseBad && pending.RepeatCount < 3) //il comando eseguito ha dato errore
+                        mRetryQueue = new GrblCommand(pending.Command, pending.RepeatCount + 1); //repeat on error
+                }
+
+                if (InProgram && mQueuePtr.Count == 0 && mPending.Count == 0)
+                    OnProgramEnd();
+            }
+            catch (Exception ex)
+            {
+                Logger.LogMessage("CommandResponse", "Ex on [{0}] message", rline);
+                Logger.LogException("CommandResponse", ex);
+            }
+        }
+
+        protected static char[] trimarray = new char[] { '\r', '\n', ' ' };
+        private string WaitComLineOrDisconnect()
+        {
+            try
+            {
+                string rv = com.ReadLineBlocking();
+                rv = rv.TrimEnd(trimarray); //rimuovi ritorno a capo
+                rv = rv.Trim(); //rimuovi spazi iniziali e finali
+                return rv.Length > 0 ? rv : null;
+            }
+            catch
+            {
+                try { CloseCom(false); }
+                catch { }
+                return null;
+            }
+        }
+
+        private bool HasIncomingData()
+        {
+            try
+            {
+                return com.HasData();
+            }
+            catch
+            {
+                try { CloseCom(false); }
+                catch { }
+                return false;
+            }
+        }
+
+        public void ManageOverrides()
+        {
+            if (mTarOvLinear == 100 && mCurOvLinear != 100) //devo fare un reset
+                SendImmediate(144);
+            else if (mTarOvLinear - mCurOvLinear >= 10) //devo fare un bigstep +
+                SendImmediate(145);
+            else if (mCurOvLinear - mTarOvLinear >= 10) //devo fare un bigstep -
+                SendImmediate(146);
+            else if (mTarOvLinear - mCurOvLinear >= 1) //devo fare uno smallstep +
+                SendImmediate(147);
+            else if (mCurOvLinear - mTarOvLinear >= 1) //devo fare uno smallstep -
+                SendImmediate(148);
+
+            if (mTarOvPower == 100 && mCurOvPower != 100) //devo fare un reset
+                SendImmediate(153);
+            else if (mTarOvPower - mCurOvPower >= 10) //devo fare un bigstep +
+                SendImmediate(154);
+            else if (mCurOvPower - mTarOvPower >= 10) //devo fare un bigstep -
+                SendImmediate(155);
+            else if (mTarOvPower - mCurOvPower >= 1) //devo fare uno smallstep +
+                SendImmediate(156);
+            else if (mCurOvPower - mTarOvPower >= 1) //devo fare uno smallstep -
+                SendImmediate(157);
+
+            if (mTarOvRapids == 100 && mCurOvRapids != 100)
+                SendImmediate(149);
+            else if (mTarOvRapids == 50 && mCurOvRapids != 50)
+                SendImmediate(150);
+            else if (mTarOvRapids == 25 && mCurOvRapids != 25)
+                SendImmediate(151);
+        }
+
+        private void ParseOverrides(string data)
+        {
+            //Ov:100,100,100
+            //indicates current override values in percent of programmed values
+            //for feed, rapids, and spindle speed, respectively.
+
+            data = data.Substring(data.IndexOf(':') + 1);
+            string[] arr = data.Split(",".ToCharArray());
+
+            ChangeOverrides(int.Parse(arr[0]), int.Parse(arr[1]), int.Parse(arr[2]));
+            ManageOverrides();
+        }
+
+        private void ChangeOverrides(int feed, int rapids, int spindle)
+        {
+            bool notify = (feed != mCurOvLinear || rapids != mCurOvRapids || spindle != mCurOvPower);
+            mCurOvLinear = feed;
+            mCurOvRapids = rapids;
+            mCurOvPower = spindle;
+
+            if (notify)
+                RiseOverrideChanged();
+        }
+
+        public int OverrideG1
+        { get { return mCurOvLinear; } }
+
+        public int OverrideG0
+        { get { return mCurOvRapids; } }
+
+        public int OverrideS
+        { get { return mCurOvPower; } }
+
+        public int TOverrideG1
+        {
+            get { return mTarOvLinear; }
+            set { mTarOvLinear = value; }
+        }
+
+        public int TOverrideG0
+        {
+            get { return mTarOvRapids; }
+            set { mTarOvRapids = value; }
+        }
+
+        public int TOverrideS
+        {
+            get { return mTarOvPower; }
+            set { mTarOvPower = value; }
+        }
+
+        protected virtual void ParseMachineStatus(string data)
+        {
+            if (data.Contains(":"))
+                data = data.Substring(0, data.IndexOf(':'));
+
+            MacStatus var = (MacStatus)Enum.Parse(typeof(MacStatus), data);
+
+            if (InProgram && var == MacStatus.Idle) //bugfix for grbl sending Idle on G4
+                var = MacStatus.Run;
+
+            if (var == MacStatus.Hold && mHoldByCoolingRequest)
+                var = MacStatus.Cooling;
+            else if (var == MacStatus.Hold && !mHoldByUserRequest)
+                var = MacStatus.AutoHold;
+
+            SetStatus(var);
+        }
+
+
+        protected virtual void ForceStatusIdle() { } // Used by Marlin to update status to Idle (As Marlin has no immediate message)
+
+        private void OnProgramEnd()
+        {
+            if (mTP.JobEnd(mLoopCount == 1) && mLoopCount > 1 && mMachineStatus != MacStatus.Check)
+            {
+                Logger.LogMessage("CycleEnd", "Cycle Executed: {0} lines, {1} errors, {2}", file.Count, mTP.ErrorCount, Tools.Utils.TimeSpanToString(ProgramTime, Tools.Utils.TimePrecision.Second, Tools.Utils.TimePrecision.Second, ",", true));
+                mSentPtr.Add(new GrblMessage(string.Format("[{0} lines, {1} errors, {2}]", file.Count, mTP.ErrorCount, Tools.Utils.TimeSpanToString(ProgramTime, Tools.Utils.TimePrecision.Second, Tools.Utils.TimePrecision.Second, ",", true)), false));
+
+                LoopCount--;
+                RunProgramFromStart(false, false, true);
+            }
+            else
+            {
+                Logger.LogMessage("ProgramEnd", "Job Executed: {0} lines, {1} errors, {2}", file.Count, mTP.ErrorCount, Tools.Utils.TimeSpanToString(ProgramTime, Tools.Utils.TimePrecision.Second, Tools.Utils.TimePrecision.Second, ",", true));
+                mSentPtr.Add(new GrblMessage(string.Format("[{0} lines, {1} errors, {2}]", file.Count, mTP.ErrorCount, Tools.Utils.TimeSpanToString(ProgramTime, Tools.Utils.TimePrecision.Second, Tools.Utils.TimePrecision.Second, ",", true)), false));
+
+                OnJobEnd();
+
+                SoundEvent.PlaySound(SoundEvent.EventId.Success);
+
+                if (ProgramGlobalTime.TotalMinutes >= (int)Settings.GetObject("TelegramNotification.Threshold", 1))
+                    Telegram.NotifyEvent(String.Format("<b>Job Executed</b>\n{0} lines, {1} errors\nTime: {2}", file.Count, mTP.ErrorCount, Tools.Utils.TimeSpanToString(ProgramGlobalTime, Tools.Utils.TimePrecision.Second, Tools.Utils.TimePrecision.Second, ",", true)));
+
+                ForceStatusIdle();
+            }
+        }
+
+        private bool InPause
+        { get { return mMachineStatus != MacStatus.Run && mMachineStatus != MacStatus.Idle; } }
+
+        private void ClearQueue(bool sent)
+        {
+            mQueue.Clear();
+            mPending.Clear();
+            if (sent) mSent.Clear();
+            mRetryQueue = null;
+        }
+
+        public bool CanReOpenFile
+        {
+            get
+            {
+                string lastFile = Settings.GetObject<string>("Core.LastOpenFile", null);
+                return CanLoadNewFile && lastFile != null && System.IO.File.Exists(lastFile);
+            }
+        }
+
+        public bool QueueEmpty { get { return mQueue.Count == 0; } }
+
+        public bool CanLoadNewFile
+        { get { return !InProgram; } }
+
+        public bool CanSendFile
+        { get { return IsConnected && HasProgram && IdleOrCheck && QueueEmpty && !mDoingSend; } }
+
+        public bool CanAbortProgram
+        { get { return IsConnected && HasProgram && (MachineStatus == MacStatus.Run || IsAnyHoldState(MachineStatus)) || !QueueEmpty; } }
+
+        public bool CanImportExport
+        { get { return IsConnected && MachineStatus == MacStatus.Idle; } }
+
+        public bool CanResetGrbl
+        { get { return IsConnected && MachineStatus != MacStatus.Disconnected; } }
+
+        public bool CanSendManualCommand
+        { get { return IsConnected && MachineStatus != MacStatus.Disconnected && !InProgram; } }
+
+        public bool CanDoHoming
+        { get { return IsConnected && (MachineStatus == MacStatus.Idle || MachineStatus == GrblCore.MacStatus.Alarm) && Configuration.HomingEnabled; } }
+
+        public bool CanDoZeroing
+        { get { return IsConnected && MachineStatus == MacStatus.Idle && WorkPosition != GPoint.Zero; } }
+
+        public bool CanUnlock
+        { get { return IsConnected && (MachineStatus == MacStatus.Idle || MachineStatus == GrblCore.MacStatus.Alarm); } }
+
+        public bool CanFeedHold
+        { get { return IsConnected && MachineStatus == MacStatus.Run; } }
+
+        public bool CanResumeHold
+        { get { return IsConnected && (MachineStatus == MacStatus.Door || IsAnyHoldState(MachineStatus)); } }
+
+        public bool CanReadWriteConfig
+        { get { return IsConnected && !InProgram && (MachineStatus == MacStatus.Idle || MachineStatus == MacStatus.Alarm); } }
+
+        public decimal LoopCount
+        { get { return mLoopCount; } set { mLoopCount = value; if (OnLoopCountChange != null) OnLoopCountChange(mLoopCount); } }
+
+        private ThreadingMode CurrentThreadingMode
+        { get { return Settings.GetObject("Threading Mode", ThreadingMode.UltraFast); } }
+
+        public virtual StreamingMode CurrentStreamingMode
+        { get { return Settings.GetObject("Streaming Mode", StreamingMode.Buffered); } }
+
+        private bool IdleOrCheck
+        { get { return MachineStatus == MacStatus.Idle || MachineStatus == MacStatus.Check; } }
+
+        public bool AutoCooling
+        { get { return Settings.GetObject("AutoCooling", false) && SupportAutoCooling; } }
+        public bool SupportAutoCooling { get => GrblVersion != null && GrblVersion >= new GrblVersionInfo(1, 1) && Configuration != null && Configuration.LaserMode; }
+
+        public TimeSpan AutoCoolingOn
+        { get { return Settings.GetObject("AutoCooling TOn", TimeSpan.FromMinutes(10)); } }
+
+        public TimeSpan AutoCoolingOff
+        { get { return Settings.GetObject("AutoCooling TOff", TimeSpan.FromMinutes(1)); } }
+
+        private void ManageCoolingCycles()
+        {
+            if (AutoCooling && InProgram && MachineStatus != MacStatus.Hold && MachineStatus != MacStatus.AutoHold)
+                NowCooling = (ProgramGlobalTime.Ticks % (AutoCoolingOn + AutoCoolingOff).Ticks) > AutoCoolingOn.Ticks;
+        }
+
+        protected bool mHoldByUserRequest = false;
+        protected bool mHoldByCoolingRequest = false;
+        private bool mNowCooling = false;
+        private bool NowCooling
+        {
+            set
+            {
+                if (mNowCooling != value)
+                {
+                    if (value)
+                        StartCooling();
+                    else
+                        ResumeCooling();
+
+                    mNowCooling = value;
+                }
+            }
+        }
+
+        private void StartCooling()
+        {
+            if (SupportLaserMode && Configuration.LaserMode)
+            {
+                FeedHold(true);
+            }
+            else //TODO: emulate pause by pushing laser off and sleep into stream
+            {
+
+            }
+        }
+
+        private void ResumeCooling()
+        {
+            if (SupportLaserMode && Configuration.LaserMode)
+            {
+                CycleStartResume(true);
+            }
+        }
+
+        private static string mDataPath;
+        public static string DataPath
+        {
+            get
+            {
+                if (mDataPath == null)
+                {
+                    mDataPath = System.IO.Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "LaserGRBL");
+                    if (!System.IO.Directory.Exists(mDataPath))
+                        System.IO.Directory.CreateDirectory(mDataPath);
+                }
+
+                return mDataPath;
+            }
+        }
+
+        public static string ExePath
+        {
+            get { return System.IO.Path.GetDirectoryName(Application.ExecutablePath); }
+        }
+
+        private static string mTempPath;
+        public static string TempPath
+        {
+            get
+            {
+                if (mTempPath == null)
+                {
+                    mTempPath = System.IO.Path.Combine(System.IO.Path.GetTempPath(), "LaserGRBL");
+                    if (!System.IO.Directory.Exists(mTempPath))
+                        System.IO.Directory.CreateDirectory(mTempPath);
+                }
+
+                return mTempPath;
+            }
+        }
+
+
+        public static string TranslateEnum(Enum value)
+        {
+            try
+            {
+                string rv = Strings.ResourceManager.GetString(value.GetType().Name + value.ToString());
+                return string.IsNullOrEmpty(rv) ? value.ToString() : rv;
+            }
+            catch { return value.ToString(); }
+        }
+
+
+        internal bool ManageHotKeys(Form parent, System.Windows.Forms.Keys keys)
+        {
+            if (SuspendHK)
+                return false;
+            return mHotKeyManager.ManageHotKeys(parent, keys);
+        }
+
+        internal void HKConnectDisconnect()
+        {
+            if (IsConnected)
+                HKDisconnect();
+            else
+                HKConnect();
+        }
+
+        internal void HKConnect()
+        {
+            if (!IsConnected)
+                OpenCom();
+        }
+
+        internal void HKDisconnect()
+        {
+            if (IsConnected)
+            {
+                if (!(InProgram && System.Windows.Forms.MessageBox.Show(Strings.DisconnectAnyway, Strings.WarnMessageBoxHeader, System.Windows.Forms.MessageBoxButtons.YesNo, System.Windows.Forms.MessageBoxIcon.Warning, System.Windows.Forms.MessageBoxDefaultButton.Button2) != System.Windows.Forms.DialogResult.Yes))
+                    CloseCom(true);
+            }
+        }
+
+        internal void HelpOnLine()
+        { Tools.Utils.OpenLink(@"https://lasergrbl.com/usage/"); }
+
+        internal void GrblHoming()
+        { if (CanDoHoming) EnqueueCommand(new GrblCommand("$H")); }
+
+        internal void GrblUnlock()
+        { if (CanUnlock) EnqueueCommand(new GrblCommand("$X")); }
+
+        internal void SetNewZero()
+        { if (CanDoZeroing) EnqueueCommand(new GrblCommand("G92 X0 Y0 Z0")); }
+
+        public int JogSpeed { get; set; }
+        public decimal JogStep { get; set; }
+
+        public bool ContinuosJogEnabled { get { return Settings.GetObject("Enable Continuous Jog", false); } }
+
+        public bool SuspendHK { get; set; }
+
+        public HotKeysManager HotKeys { get { return mHotKeyManager; } }
+
+        internal void WriteHotkeys(System.Collections.Generic.List<HotKeysManager.HotKey> mLocalList)
+        {
+            mHotKeyManager.Clear();
+            mHotKeyManager.AddRange(mLocalList);
+            Settings.SetObject("Hotkey Setup", mHotKeyManager);
+        }
+
+        //internal void HKCustomButton(int index)
+        //{
+        //	CustomButton cb = CustomButtons.GetButton(index);
+        //	if (cb != null && cb.EnabledNow(this))
+        //		ExecuteCustombutton(cb.GCode);
+        //}
+
+        static System.Text.RegularExpressions.Regex bracketsRegEx = new System.Text.RegularExpressions.Regex(@"\[(?:[^]]+)\]");
+        internal void ExecuteCustombutton(string buttoncode)
+        {
+            buttoncode = buttoncode.Trim();
+            string[] arr = buttoncode.Split(new string[] { Environment.NewLine }, StringSplitOptions.None);
+            foreach (string str in arr)
+            {
+                if (str.Trim().Length > 0)
+                {
+                    string tosend = EvaluateExpression(str);
+
+                    if (IsImmediate(tosend))
+                    {
+                        byte b = GetImmediate(tosend);
+                        if (b == '!') mHoldByUserRequest = true;
+                        SendImmediate(b);
+                    }
+                    else
+                    { EnqueueCommand(new GrblCommand(tosend)); }
+                }
+            }
+        }
+
+        internal string EvaluateExpression(string str)
+        {
+            return bracketsRegEx.Replace(str, new System.Text.RegularExpressions.MatchEvaluator(EvaluateCB)).Trim();
+        }
+
+        bool IsImmediate(string code)
+        {
+            if (code.ToLower() == "ctrl-x")
+                return true;
+            if (code == "?")
+                return true;
+            if (code == "!")
+                return true;
+            if (code == "~")
+                return true;
+
+            if (code.ToLower().StartsWith("0x"))
+            {
+                try
+                {
+                    byte value = Convert.ToByte(code, 16);
+                    return true;
+                }
+                catch { return false; }
+            }
+
+            return false;
+        }
+
+        byte GetImmediate(string code)
+        {
+            if (code.ToLower() == "ctrl-x")
+                return 24;
+            if (code == "?")
+                return 63;
+            if (code == "!")
+                return 33;
+            if (code == "~")
+                return 126;
+
+            byte value = Convert.ToByte(code, 16);
+            return value;
+        }
+
+
+        private string EvaluateCB(System.Text.RegularExpressions.Match m)
+        {
+            try
+            {
+                decimal left = LoadedFile != null && LoadedFile.Range.DrawingRange.ValidRange ? LoadedFile.Range.DrawingRange.X.Min : 0;
+                decimal right = LoadedFile != null && LoadedFile.Range.DrawingRange.ValidRange ? LoadedFile.Range.DrawingRange.X.Max : 0;
+                decimal top = LoadedFile != null && LoadedFile.Range.DrawingRange.ValidRange ? LoadedFile.Range.DrawingRange.Y.Max : 0;
+                decimal bottom = LoadedFile != null && LoadedFile.Range.DrawingRange.ValidRange ? LoadedFile.Range.DrawingRange.Y.Min : 0;
+                decimal width = right - left;
+                decimal height = top - bottom;
+                decimal jogstep = JogStep;
+                decimal jogspeed = JogSpeed;
+
+                String text = m.Value.Substring(1, m.Value.Length - 2);
+                Tools.Expression exp = new Tools.Expression(text);
+
+                exp.AddSetVariable("left", (double)left);
+                exp.AddSetVariable("right", (double)right);
+                exp.AddSetVariable("top", (double)top);
+                exp.AddSetVariable("bottom", (double)bottom);
+                exp.AddSetVariable("width", (double)width);
+                exp.AddSetVariable("height", (double)height);
+                exp.AddSetVariable("jogstep", (double)jogstep);
+                exp.AddSetVariable("jogspeed", (double)jogspeed);
+                exp.AddSetVariable("WCO.X", (double)WorkingOffset.X);
+                exp.AddSetVariable("WCO.Y", (double)WorkingOffset.Y);
+                exp.AddSetVariable("WCO.Z", (double)WorkingOffset.Z);
+                exp.AddSetVariable("MPos.X", (double)MachinePosition.X);
+                exp.AddSetVariable("MPos.Y", (double)MachinePosition.Y);
+                exp.AddSetVariable("MPos.Z", (double)MachinePosition.Z);
+                exp.AddSetVariable("WPos.X", (double)MachinePosition.X);
+                exp.AddSetVariable("WPos.Y", (double)MachinePosition.Y);
+                exp.AddSetVariable("WPos.Z", (double)MachinePosition.Z);
+
+                GrblConfST conf = Configuration;
+                if (conf != null)
+                {
+                    foreach (KeyValuePair<int, string> p in conf)
+                    {
+                        if (double.TryParse(p.Value, NumberStyles.Any, CultureInfo.InvariantCulture, out double tod)) //aggiungi solo ciò che si riesce a convertire in double
+                            exp.AddSetVariable("$" + p.Key, tod);
+                    }
+                }
+
+                double dval = exp.EvaluateD();
+                return m.Result(FormatNumber((decimal)dval));
+            }
+            catch { return m.Value; }
+        }
+
+        static string FormatNumber(decimal value)
+        { return string.Format(System.Globalization.CultureInfo.InvariantCulture, "{0:0.000}", value); }
+
+
+        public float CurrentF { get { return mCurF; } }
+        public float CurrentS { get { return mCurS; } }
+
+        private static IEnumerable<GrblCommand> StringToGCode(string input)
+        {
+            if (string.IsNullOrEmpty(input))
+                yield break;
+
+            using (System.IO.StringReader reader = new System.IO.StringReader(input))
+            {
+                string line;
+                while (!string.IsNullOrEmpty(line = reader.ReadLine()))
+                    yield return new GrblCommand(line);
+            }
+        }
+
+        public virtual bool UIShowGrblConfig => true;
+        public virtual bool UIShowUnlockButtons => true;
+
+        public bool IsOrturBoard { get => GrblVersion != null && GrblVersion.IsOrtur; }
+        public int FailedConnectionCount => mFailedConnection;
+    }
+
+    public class TimeProjection
+    {
+        private TimeSpan mETarget;
+        private TimeSpan mEProgress;
+
+
+        private long mStart;        //Start Time
+        private long mEnd;          //End Time
+        private long mGlobalStart;  //Global Start (multiple pass)
+        private long mGlobalEnd;    //Global End (multiple pass)
+        private long mPauseBegin;   //Pause begin Time
+        private long mCumulatedPause;
+
+        private bool mInPause;
+        private bool mCompleted;
+        private bool mStarted;
+
+        private int mTargetCount;
+        private int mExecutedCount;
+        private int mSentCount;
+        private int mErrorCount;
+        private int mContinueCorrection;
+
+        GrblCore.DetectedIssue mLastIssue;
+        private GPoint mLastKnownWCO;
+
+        public GPoint LastKnownWCO
+        {
+            get { return mLastKnownWCO; }
+            set { if (InProgram) mLastKnownWCO = value; }
+        }
+
+        public TimeProjection()
+        { Reset(true); }
+
+        public void Reset(bool global)
+        {
+            mETarget = TimeSpan.Zero;
+            mEProgress = TimeSpan.Zero;
+            mStart = mEnd = 0;
+            if (global) mGlobalStart = mGlobalEnd = 0;
+            mPauseBegin = 0;
+            mCumulatedPause = 0;
+            mInPause = false;
+            mCompleted = false;
+            mStarted = false;
+            mExecutedCount = 0;
+            mSentCount = 0;
+            mErrorCount = 0;
+            mTargetCount = 0;
+            mContinueCorrection = 0;
+            mLastIssue = GrblCore.DetectedIssue.Unknown;
+            mLastKnownWCO = GPoint.Zero;
+        }
+
+        public TimeSpan EstimatedTarget
+        { get { return mETarget; } }
+
+        public bool InProgram
+        { get { return mStarted && !mCompleted; } }
+
+        public int Target
+        { get { return mTargetCount; } }
+
+        public int Sent
+        { get { return mSentCount - mContinueCorrection; } }
+
+        public int Executed
+        { get { return mExecutedCount - mContinueCorrection; } }
+
+        public TimeSpan ProjectedTarget
+        {
+            get
+            {
+                if (mStarted)
+                {
+                    double real = TrueJobTime.TotalSeconds; //job time spent in execution
+                    double target = mETarget.TotalSeconds;  //total estimated
+                    double done = mEProgress.TotalSeconds;  //done of estimated
+
+                    if (done != 0)
+                        return TimeSpan.FromSeconds(real * target / done) + TotalJobPauses;
+                    else
+                        return EstimatedTarget;
+                }
+                else
+                    return TimeSpan.Zero;
+            }
+        }
+
+        private TimeSpan TrueJobTime
+        { get { return TotalJobTime - TotalJobPauses; } }
+
+        public TimeSpan TotalJobTime
+        {
+            get
+            {
+                if (mCompleted)
+                    return TimeSpan.FromMilliseconds(mEnd - mStart);
+                else if (mStarted)
+                    return TimeSpan.FromMilliseconds(now - mStart);
+                else
+                    return TimeSpan.Zero;
+            }
+        }
+
+        public TimeSpan TotalGlobalJobTime
+        {
+            get
+            {
+                if (mCompleted)
+                    return TimeSpan.FromMilliseconds(mGlobalEnd - mGlobalStart);
+                else if (mStarted)
+                    return TimeSpan.FromMilliseconds(now - mGlobalStart);
+                else
+                    return TimeSpan.Zero;
+            }
+        }
+
+        private TimeSpan TotalJobPauses
+        {
+            get
+            {
+                if (mInPause)
+                    return TimeSpan.FromMilliseconds(mCumulatedPause + (now - mPauseBegin));
+                else
+                    return TimeSpan.FromMilliseconds(mCumulatedPause);
+            }
+        }
+
+        public void JobStart(GrblFile file, Queue<GrblCommand> mQueuePtr, bool global)
+        {
+            if (!mStarted)
+            {
+                mETarget = file.EstimatedTime;
+                mTargetCount = mQueuePtr.Count;
+                mEProgress = TimeSpan.Zero;
+                mStart = Tools.HiResTimer.TotalMilliseconds;
+                if (global) mGlobalStart = mStart;
+                mPauseBegin = 0;
+                mInPause = false;
+                mCompleted = false;
+                mStarted = true;
+                mExecutedCount = 0;
+                mSentCount = 0;
+                mErrorCount = 0;
+                mContinueCorrection = 0;
+                mLastIssue = GrblCore.DetectedIssue.Unknown;
+                mLastKnownWCO = GPoint.Zero;
+            }
+        }
+
+        public void JobContinue(GrblFile file, int position, int added)
+        {
+            if (!mStarted)
+            {
+                if (mETarget == TimeSpan.Zero) mETarget = file.EstimatedTime;
+                if (mTargetCount == 0) mTargetCount = file.Count;
+                //mEProgress = TimeSpan.Zero;
+                if (mStart == 0)
+                    mGlobalStart = mStart = Tools.HiResTimer.TotalMilliseconds;
+
+                mPauseBegin = 0;
+                mInPause = false;
+                mCompleted = false;
+                mStarted = true;
+                mExecutedCount = position;
+                mSentCount = position;
+                mLastIssue = GrblCore.DetectedIssue.Unknown;
+                //	mErrorCount = 0;
+                mContinueCorrection = added;
+            }
+        }
+
+        public void JobSent()
+        {
+            if (mStarted && !mCompleted)
+                mSentCount++;
+        }
+
+        public void JobError()
+        {
+            if (mStarted && !mCompleted)
+            {
+                SoundEvent.PlaySound(SoundEvent.EventId.Warning);
+                mErrorCount++;
+            }
+        }
+
+        public void JobExecuted(TimeSpan EstimatedProgress)
+        {
+            if (mStarted && !mCompleted)
+            {
+                mExecutedCount++;
+                mEProgress = EstimatedProgress;
+            }
+        }
+
+        public void JobPause()
+        {
+            if (mStarted && !mCompleted && !mInPause)
+            {
+                mInPause = true;
+                mPauseBegin = now;
+            }
+        }
+
+        public void JobResume()
+        {
+            if (mStarted && !mCompleted && mInPause)
+            {
+                mCumulatedPause += Tools.HiResTimer.TotalMilliseconds - mPauseBegin;
+                mInPause = false;
+            }
+        }
+
+        public bool JobEnd(bool global)
+        {
+            if (mStarted && !mCompleted)
+            {
+                JobResume(); //nel caso l'ultimo comando fosse una pausa, la chiudo e la cumulo
+                mEnd = Tools.HiResTimer.TotalMilliseconds;
+                if (global) mGlobalEnd = mEnd;
+                mCompleted = true;
+                mStarted = false;
+                return true;
+            }
+
+            return false;
+        }
+
+        public void JobIssue(GrblCore.DetectedIssue issue)
+        { mLastIssue = issue; }
+
+        private long now
+        { get { return Tools.HiResTimer.TotalMilliseconds; } }
+
+        public int ErrorCount
+        { get { return mErrorCount; } }
+
+        public GrblCore.DetectedIssue LastIssue
+        { get { return mLastIssue; } }
+
+
+        //private Tools.ElapsedFromEvent crono = new Tools.ElapsedFromEvent();
+
+        //private string LastJobFileName => System.IO.Path.Combine(GrblCore.DataPath, "lastjob.nc");
+        //private string LastPositionFileName => System.IO.Path.Combine(GrblCore.DataPath, "jobprogress.dat");
+
+        //public void LoadFile(GrblFile file)
+        //{
+        //	try
+        //	{
+        //		if (System.IO.File.Exists(LastJobFileName))
+        //			System.IO.File.Delete(LastJobFileName);
+        //		if (file.Count > 0)
+        //			file.SaveProgram(LastJobFileName, false, false, false, 1);
+        //	}
+        //	catch
+        //	{ }
+        //}
+
+        //public void JobBegin()
+        //{
+        //	try
+        //	{
+        //		if (System.IO.File.Exists(LastPositionFileName))
+        //			System.IO.File.Delete(LastPositionFileName);
+
+        //		crono.Start();
+        //		WriteCurrentPosition();
+        //	}
+        //	catch
+        //	{ }
+        //}
+
+        //public void JobEnd()
+        //{
+        //	//try
+        //	//{
+        //	//	if (System.IO.File.Exists(LastPositionFileName))
+        //	//		System.IO.File.Delete(LastPositionFileName);
+        //	//}
+        //	//catch
+        //	//{ }
+        //}
+
+        //public void JobProgress()
+        //{
+        //	try
+        //	{
+        //		if (crono.ElapsedTime > TimeSpan.FromSeconds(10))
+        //		{
+        //			crono.Start();
+        //			WriteCurrentPosition();
+        //		}
+        //	}
+        //	catch
+        //	{ }
+        //}
+
+        //private void WriteCurrentPosition()
+        //{
+        //	using (System.IO.FileStream fs = new System.IO.FileStream(LastPositionFileName, System.IO.FileMode.Create))
+        //	{
+        //		using (System.IO.BinaryWriter w = new System.IO.BinaryWriter(fs))
+        //		{
+        //			int exec = Executed;
+        //			int sent = Sent;
+        //			int target = Target;
+
+        //			w.Write(exec);
+        //			w.Write(sent);
+        //			w.Write(target);
+        //			w.Write(exec ^ sent ^ target ^ 0x55555555); //checksum valid data
+        //		}
+        //	}
+        //}
+    }
+
+    [Serializable]
+    public class GrblConfST : IEnumerable<KeyValuePair<int, string>>
+    {
+        private const decimal MAX_CONFIG_SPEED = 2000000;
+        private const decimal MAX_CONFIG_PWM = 2000000;
+        private const decimal MAX_CONFIG_RESOLUTION = 10000;
+        private const decimal MAX_CONFIG_SIZE = 2000000;
+        private const decimal MAX_CONFIG_ACCEL = 2000000;
+
+
+        public class GrblConfParam : ICloneable
+        {
+            private int mNumber;
+            private string mValue;
+
+            public GrblConfParam(int number, string value)
+            { mNumber = number; mValue = value; }
+
+            public int Number
+            { get { return mNumber; } }
+
+            public string DollarNumber
+            { get { return "$" + mNumber.ToString(); } }
+
+            public string Parameter
+            { get { return CSVD.Settings.GetItem(mNumber.ToString(), 0); } }
+
+            //public decimal Value
+            //{
+            //	get { return decimal.Parse(mValue, CultureInfo.InvariantCulture); }
+            //	set { mValue = value.ToString(CultureInfo.InvariantCulture); }
+            //}
+
+            public string Value
+            {
+                get { return mValue; }
+                set { mValue = value; }
+            }
+
+            public string Unit
+            { get { return CSVD.Settings.GetItem(mNumber.ToString(), 1); } }
+
+            public string Description
+            { get { return CSVD.Settings.GetItem(mNumber.ToString(), 2); } }
+
+            public object Clone()
+            { return this.MemberwiseClone(); }
+
+        }
+
+        private Dictionary<int, string> mData;
+        private GrblCore.GrblVersionInfo mVersion;
+
+
+        public GrblConfST()
+        {
+            mData = new Dictionary<int, string>();
+        }
+
+        public GrblConfST(GrblCore.GrblVersionInfo GrblVersion) : this()
+        {
+            mVersion = GrblVersion;
+        }
+
+        public GrblConfST(GrblCore.GrblVersionInfo GrblVersion, Dictionary<int, string> configTable) : this(GrblVersion)
+        {
+            foreach (KeyValuePair<int, string> kvp in configTable)
+                mData.Add(kvp.Key, kvp.Value);
+        }
+
+        public GrblConfST(GrblConf old) : this(old?.GrblVersion)
+        {
+            if (old != null)
+                foreach (KeyValuePair<int, decimal> kvp in old)
+                    mData.Add(kvp.Key, kvp.Value.ToString(CultureInfo.InvariantCulture));
+        }
+
+        public GrblCore.GrblVersionInfo GrblVersion => mVersion;
+        private bool NoVersionInfo => mVersion == null;
+        private bool Version11 => mVersion != null && mVersion >= new GrblCore.GrblVersionInfo(1, 1);
+        private bool Version9 => mVersion != null && mVersion >= new GrblCore.GrblVersionInfo(0, 9);
+
+        public int ExpectedCount => Version11 ? 34 : Version9 ? 31 : 23;
+        public bool HomingEnabled => ReadDecimal(Version9 ? 22 : 17, 1, 0, 1) != 0;
+        public decimal MaxRateX => ReadDecimal(Version9 ? 110 : 4, 4000, 1, MAX_CONFIG_SPEED);
+        public decimal MaxRateY => ReadDecimal(Version9 ? 111 : 5, 4000, 1, MAX_CONFIG_SPEED);
+
+        public bool LaserMode
+        {
+            get
+            {
+                if (NoVersionInfo)
+                    return true;
+                else
+                    return ReadDecimal(Version11 ? 32 : -1, 0, 0, 1) != 0;
+            }
+        }
+
+        public decimal MinPWM => ReadDecimal(Version11 ? 31 : -1, 0, 0, MAX_CONFIG_PWM);
+        public decimal MaxPWM => ReadDecimal(Version11 ? 30 : -1, 1000, 1, MAX_CONFIG_PWM);
+        public decimal ResolutionX => ReadDecimal(Version9 ? 100 : 0, 250, 1, MAX_CONFIG_RESOLUTION);
+        public decimal ResolutionY => ReadDecimal(Version9 ? 101 : 1, 250, 1, MAX_CONFIG_RESOLUTION);
+        public decimal TableWidth => ReadDecimal(Version9 ? 130 : -1, 300, 1, MAX_CONFIG_SIZE);
+        public decimal TableHeight => ReadDecimal(Version9 ? 131 : -1, 200, 1, MAX_CONFIG_SIZE);
+        public bool SoftLimit => ReadDecimal(20, 0, 0, 1) != 0;
+
+        public decimal AccelerationXY => (AccelerationX + AccelerationY) / 2;
+        private decimal AccelerationX => ReadDecimal(Version9 ? 120 : -1, 2000, 1, MAX_CONFIG_ACCEL);
+        private decimal AccelerationY => ReadDecimal(Version9 ? 121 : -1, 2000, 1, MAX_CONFIG_ACCEL);
+
+        public string WiFi_SSID => ReadString(74, null);
+        public string WiFi_Pwd => ReadString(75, null);
+        public string TelnetPort => ReadString(305, "23");
+
+
+        private decimal ReadDecimal(int key, decimal defval, decimal min, decimal max)
+        {
+            if (mVersion == null)
+                return defval;
+            else if (!mData.ContainsKey(key))
+                return defval;
+            else
+            {
+                try
+                {
+                    return Math.Max(min, Math.Min(max, decimal.Parse(mData[key], CultureInfo.InvariantCulture)));
+                }
+                catch
+                {
+                    try //proviamo a pulire la stringa con una regex?!
+                    {
+                        System.Text.RegularExpressions.Regex ExtractNumber = new System.Text.RegularExpressions.Regex(@"(\d+\.?\d*)");
+                        System.Text.RegularExpressions.MatchCollection matches = ExtractNumber.Matches(mData[key]);
+                        return decimal.Parse(matches[0].Groups[1].Value);
+                    }
+                    catch
+                    {
+                        return defval;
+                    }
+                }
+            }
+        }
+
+        private string ReadString(int number, string defval)
+        {
+            if (mVersion == null)
+                return defval;
+            else if (!mData.ContainsKey(number))
+                return defval;
+            else
+                return mData[number];
+        }
+
+        public List<GrblConfParam> ToList()
+        {
+            List<GrblConfParam> rv = new List<GrblConfParam>();
+            foreach (KeyValuePair<int, string> kvp in mData)
+                rv.Add(new GrblConfParam(kvp.Key, kvp.Value));
+            return rv;
+        }
+
+        public int Count { get { return mData.Count; } }
+
+
+
+        internal bool HasChanges(GrblConfParam p)
+        {
+            if (!mData.ContainsKey(p.Number))
+                return true;
+            else if (mData[p.Number] != p.Value)
+                return true;
+            else
+                return false;
+        }
+
+        private bool ContainsKey(int key)
+        {
+            return mData.ContainsKey(key);
+        }
+
+
+        public IEnumerator<KeyValuePair<int, string>> GetEnumerator()
+        {
+            return mData.GetEnumerator();
+        }
+
+        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator()
+        {
+            return mData.GetEnumerator();
+        }
+
+        // "$" at the beginning of a line, followed by numbers, by any spaces, by "=" and then averything
+        private static System.Text.RegularExpressions.Regex ConfRegEX = new System.Text.RegularExpressions.Regex(@"^[$](\d+)\s*=(.*)");
+
+        public static bool IsSetConf(string p)
+        { return ConfRegEX.IsMatch(p); }
+
+        public void AddOrUpdate(string line)
+        {
+            try
+            {
+                if (IsSetConf(line))
+                {
+                    line = FixFoxalienConfig(line);
+
+                    System.Text.RegularExpressions.MatchCollection matches = ConfRegEX.Matches(line);
+                    int key = int.Parse(matches[0].Groups[1].Value);
+                    string val = matches[0].Groups[2].Value.Trim();
+
+                    if (ContainsKey(key))
+                        mData[key] = val;
+                    else
+                        mData.Add(key, val);
+                }
+            }
+            catch (Exception)
+            {
+
+            }
+        }
+
+
+        // Foxalien send config values with descriprion inside it i.e. "$20=0 (soft limits, bool)\r" , so we need to do a cleanup to remove description between parentesis
+        // See issue https://github.com/arkypita/LaserGRBL/issues/1890
+        private static System.Text.RegularExpressions.Regex FoxalienCleanupConfig = new System.Text.RegularExpressions.Regex(@"^[$](\d+)\s*=\s*(\d+\.?\d*)\s*\(.*\)");
+        private string FixFoxalienConfig(string line)
+        {
+            if (!FoxalienCleanupConfig.IsMatch(line))
+                return line;
+
+            System.Text.RegularExpressions.MatchCollection matches = FoxalienCleanupConfig.Matches(line);
+            int key = int.Parse(matches[0].Groups[1].Value);
+            string val = matches[0].Groups[2].Value.Trim();
+
+            return $"${key}={val}";
+        }
+
+        internal bool SetValueIfKeyExist(string p)
+        {
+            try
+            {
+                if (IsSetConf(p))
+                {
+                    System.Text.RegularExpressions.MatchCollection matches = ConfRegEX.Matches(p);
+                    int key = int.Parse(matches[0].Groups[1].Value);
+                    string val = matches[0].Groups[2].Value.Trim();
+
+                    if (!ContainsKey(key))
+                        return false;
+
+                    mData[key] = val;
+                    return true;
+                }
+            }
+            catch (Exception)
+            {
+
+            }
+
+            return false;
+        }
+
+        internal string ValidateConfig(int parid, object value)
+        {
+            if (parid == 33 && mVersion != null && mVersion.IsOrtur)
+                return "This param control an Ortur safety feature. Please do not change this value!";
+
+            return null;
+        }
+    }
+
+
+
+    [Serializable, Obsolete]
+    public class GrblConf : IEnumerable<KeyValuePair<int, decimal>>
+    {
+        [Obsolete]
+        public class GrblConfParam : ICloneable
+        {
+            private int mNumber;
+            private decimal mValue;
+
+            public GrblConfParam(int number, decimal value)
+            { mNumber = number; mValue = value; }
+
+            public int Number
+            { get { return mNumber; } }
+
+            public string DollarNumber
+            { get { return "$" + mNumber.ToString(); } }
+
+            public string Parameter
+            { get { return CSVD.Settings.GetItem(mNumber.ToString(), 0); } }
+
+            public decimal Value
+            {
+                get { return mValue; }
+                set { mValue = value; }
+            }
+
+            public string Unit
+            { get { return CSVD.Settings.GetItem(mNumber.ToString(), 1); } }
+
+            public string Description
+            { get { return CSVD.Settings.GetItem(mNumber.ToString(), 2); } }
+
+            public object Clone()
+            { return this.MemberwiseClone(); }
+
+        }
+
+        private System.Collections.Generic.Dictionary<int, decimal> mData;
+        private GrblCore.GrblVersionInfo mVersion;
+
+        public GrblConf(GrblCore.GrblVersionInfo GrblVersion)
+            : this()
+        {
+            mVersion = GrblVersion;
+        }
+
+        public GrblConf(GrblCore.GrblVersionInfo GrblVersion, System.Collections.Generic.Dictionary<int, decimal> configTable)
+            : this(GrblVersion)
+        {
+            foreach (System.Collections.Generic.KeyValuePair<int, decimal> kvp in configTable)
+                mData.Add(kvp.Key, kvp.Value);
+        }
+
+        public GrblConf()
+        { mData = new System.Collections.Generic.Dictionary<int, decimal>(); }
+
+        public GrblCore.GrblVersionInfo GrblVersion => mVersion;
+        private bool NoVersionInfo => mVersion == null;
+        private bool Version11 => mVersion != null && mVersion >= new GrblCore.GrblVersionInfo(1, 1);
+        private bool Version9 => mVersion != null && mVersion >= new GrblCore.GrblVersionInfo(0, 9);
+
+        public int ExpectedCount => Version11 ? 34 : Version9 ? 31 : 23;
+        public bool HomingEnabled => ReadWithDefault(Version9 ? 22 : 17, 1) != 0;
+        public decimal MaxRateX => ReadWithDefault(Version9 ? 110 : 4, 4000);
+        public decimal MaxRateY => ReadWithDefault(Version9 ? 111 : 5, 4000);
+
+        public bool LaserMode
+        {
+            get
+            {
+                if (NoVersionInfo)
+                    return true;
+                else
+                    return ReadWithDefault(Version11 ? 32 : -1, 0) != 0;
+            }
+        }
+
+        public decimal MinPWM => ReadWithDefault(Version11 ? 31 : -1, 0);
+        public decimal MaxPWM => ReadWithDefault(Version11 ? 30 : -1, 1000);
+        public decimal ResolutionX => ReadWithDefault(Version9 ? 100 : 0, 250);
+        public decimal ResolutionY => ReadWithDefault(Version9 ? 101 : 1, 250);
+        public decimal TableWidth => ReadWithDefault(Version9 ? 130 : -1, 300);
+        public decimal TableHeight => ReadWithDefault(Version9 ? 131 : -1, 200);
+        public bool SoftLimit => ReadWithDefault(20, 0) != 0;
+
+        public decimal AccelerationXY => (AccelerationX + AccelerationY) / 2;
+        private decimal AccelerationX => ReadWithDefault(Version9 ? 120 : -1, 2000);
+        private decimal AccelerationY => ReadWithDefault(Version9 ? 121 : -1, 2000);
+
+        private decimal ReadWithDefault(int number, decimal defval)
+        {
+            if (mVersion == null)
+                return defval;
+            else if (!mData.ContainsKey(number))
+                return defval;
+            else
+                return mData[number];
+        }
+
+        //public object Clone()
+        //{
+        //	GrblConf rv = new GrblConf();
+        //	rv.mVersion = mVersion != null ? mVersion.Clone() as GrblCore.GrblVersionInfo : null;
+        //	foreach (System.Collections.Generic.KeyValuePair<int, GrblConf.GrblConfParam> kvp in this)
+        //		rv.Add(kvp.Key, kvp.Value.Clone() as GrblConfParam);
+        //	return rv;
+        //}
+
+        public System.Collections.Generic.List<GrblConf.GrblConfParam> ToList()
+        {
+            System.Collections.Generic.List<GrblConfParam> rv = new System.Collections.Generic.List<GrblConfParam>();
+            foreach (System.Collections.Generic.KeyValuePair<int, decimal> kvp in mData)
+                rv.Add(new GrblConfParam(kvp.Key, kvp.Value));
+            return rv;
+        }
+
+        private void Add(int num, decimal val)
+        {
+            mData.Add(num, val);
+        }
+
+        public int Count { get { return mData.Count; } }
+
+        internal bool HasChanges(GrblConfParam p)
+        {
+            if (!mData.ContainsKey(p.Number))
+                return true;
+            else if (mData[p.Number] != p.Value)
+                return true;
+            else
+                return false;
+        }
+
+        private bool ContainsKey(int key)
+        {
+            return mData.ContainsKey(key);
+        }
+
+        private void SetValue(int key, decimal value)
+        {
+            mData[key] = value;
+        }
+
+        public System.Collections.Generic.IEnumerator<System.Collections.Generic.KeyValuePair<int, decimal>> GetEnumerator()
+        {
+            return mData.GetEnumerator();
+        }
+
+        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator()
+        {
+            return mData.GetEnumerator();
+        }
+
+
+        private static System.Text.RegularExpressions.Regex ConfRegEX = new System.Text.RegularExpressions.Regex(@"^[$](\d+) *= *(\d+\.?\d*)");
+
+        public static bool IsSetConf(string p)
+        { return ConfRegEX.IsMatch(p); }
+
+        public void AddOrUpdate(string p)
+        {
+            try
+            {
+                if (IsSetConf(p))
+                {
+                    System.Text.RegularExpressions.MatchCollection matches = ConfRegEX.Matches(p);
+                    int key = int.Parse(matches[0].Groups[1].Value);
+                    decimal val = decimal.Parse(matches[0].Groups[2].Value, System.Globalization.CultureInfo.InvariantCulture);
+
+                    if (ContainsKey(key))
+                        SetValue(key, val);
+                    else
+                        Add(key, val);
+                }
+            }
+            catch (Exception)
+            {
+
+            }
+        }
+
+        internal bool SetValueIfKeyExist(string p)
+        {
+            try
+            {
+                if (IsSetConf(p))
+                {
+                    System.Text.RegularExpressions.MatchCollection matches = ConfRegEX.Matches(p);
+                    int key = int.Parse(matches[0].Groups[1].Value);
+                    decimal val = decimal.Parse(matches[0].Groups[2].Value, System.Globalization.CultureInfo.InvariantCulture);
+
+                    if (!ContainsKey(key))
+                        return false;
+
+                    SetValue(key, val);
+                    return true;
+                }
+            }
+            catch (Exception)
+            {
+
+            }
+
+            return false;
+        }
+
+        internal string ValidateConfig(int parid, object value)
+        {
+            if (parid == 33 && mVersion != null && mVersion.IsOrtur)
+                return "This param control an Ortur safety feature. Please do not change this value!";
+
+            return null;
+        }
+    }
+
+    public struct GPoint
+    {
+        public float X, Y, Z;
+
+        public GPoint(float x, float y, float z)
+        {
+            X = x;
+            Y = y;
+            Z = z;
+        }
+
+        public static GPoint Zero { get { return new GPoint(); } }
+
+        public static bool operator ==(GPoint a, GPoint b)
+        { return a.X == b.X && a.Y == b.Y && a.Z == b.Z; }
+
+        public static bool operator !=(GPoint a, GPoint b)
+        { return !(a == b); }
+
+        public static GPoint operator -(GPoint a, GPoint b)
+        { return new GPoint(a.X - b.X, a.Y - b.Y, a.Z - b.Z); }
+
+        public static GPoint operator +(GPoint a, GPoint b)
+        { return new GPoint(a.X + b.X, a.Y + b.Y, a.Z + b.Z); }
+
+        public override bool Equals(object obj)
+        {
+            return obj is GPoint && ((GPoint)obj) == this;
+        }
+
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hash = 17;
+                hash = hash * 23 + X.GetHashCode();
+                hash = hash * 23 + Y.GetHashCode();
+                hash = hash * 23 + Z.GetHashCode();
+                return hash;
+            }
+        }
+
+        internal PointF ToPointF()
+        {
+            return new PointF(X, Y);
+        }
+    }
+
+
+    public static class LaserLifeHandler
+    {
+        [Serializable]
+        public class ListLLC : List<LaserLifeCounter>
+        {
+            public DateTime LastAttempt = new DateTime(2000, 1, 1);
+            public DateTime LastSent = new DateTime(2000, 1, 1);
+
+            internal ListLLC GetClone()
+            {
+                ListLLC clone = new ListLLC();
+
+                lock (this)
+                {
+                    foreach (LaserLifeCounter LLC in this)
+                        clone.Add(LLC.Clone());
+                    clone.LastSent = LastSent;
+                    clone.LastAttempt = LastAttempt;
+                }
+
+                return clone;
+            }
+
+            //internal void FixWeirdMeasures()
+            //{
+            //	foreach (LaserLifeCounter LLC in this)
+            //		LLC.FixWeirdMeasures();
+            //}
+        }
+
+        static ListLLC mLLCL;
+        static LaserLifeCounter mCurrentLLC;
+        private static long? mLastStatusHiResTimeNano;
+        private static long? mLastPowerHiResTimeNano;
+        private static long mLastSave;
+        private static string mLLCFileName;
+
+        [Serializable]
+        public class LaserLifeCounter : IDeserializationCallback
+        {
+            public static string DEF_NAME = "Default";
+            public static string DEF_BRAND = "Unknown";
+            public static string DEF_MODEL = "Unknown";
+            private string mGuid;
+
+            private string mName;
+            private string mBrand;
+            private string mModuleModel;
+            private double? mOpticalPower;
+
+            private DateTime? mPurchaseDate;
+            private DateTime? mMonitoringDate;
+            private DateTime? mDeathDate;
+            private DateTime? mLastUsage;
+
+            private TimeSpan mTimeInRun;
+            private TimeSpan mTimeUsageNormalizedPower;
+            private TimeSpan mTimeUsageNonZero;
+            private TimeSpan[] mTimeClasses;
+
+            public DateTime? PurchaseDate { get => mPurchaseDate; set => mPurchaseDate = value; }
+            public DateTime? MonitoringDate { get => mMonitoringDate; set => mMonitoringDate = value; }
+            public DateTime? DeathDate { get => mDeathDate; set => mDeathDate = value; }
+            public DateTime? LastUsage { get => mLastUsage; set => mLastUsage = value; }
+            public string Name { get => mName; set => mName = value; }
+            public string Brand { get => mBrand; set => mBrand = value; }
+            public string Model { get => mModuleModel; set => mModuleModel = value; }
+            public double? OpticalPower { get => mOpticalPower; set => mOpticalPower = value; }
+            public TimeSpan TimeInRun { get => mTimeInRun; }
+            public TimeSpan TimeUsageNormalizedPower { get => mTimeUsageNormalizedPower; }
+            public TimeSpan StressTime { get => mTimeClasses[9]; }
+            public double AveragePowerFactor { get => mTimeUsageNonZero.TotalSeconds == 0 ? 0 : mTimeUsageNormalizedPower.TotalSeconds / mTimeUsageNonZero.TotalSeconds; }
+            public string Guid { get => mGuid; }
+            public TimeSpan[] Classes { get => mTimeClasses; }
+
+            private LaserLifeCounter()
+            {
+                mGuid = System.Guid.NewGuid().ToString();
+                mMonitoringDate = DateTime.Today;
+                mTimeClasses = new TimeSpan[10];
+            }
+
+            internal static LaserLifeCounter CreateNew()
+            {
+                LaserLifeCounter rv = new LaserLifeCounter();
+                return rv;
+            }
+            public static LaserLifeCounter CreateDefault()
+            {
+                LaserLifeCounter rv = new LaserLifeCounter();
+                rv.Name = DEF_NAME;
+                return rv;
+            }
+
+            internal void AddRunTime(TimeSpan elapsed)
+            {
+                //elapsed = TimeSpan.FromSeconds(elapsed.TotalSeconds * 100);
+                mTimeInRun = mTimeInRun.Add(elapsed);
+                mLastUsage = DateTime.Today;
+            }
+
+            internal LaserLifeCounter Clone()
+            {
+                return MemberwiseClone() as LaserLifeCounter;
+            }
+
+            internal void AddTrueLaserTimePower(TimeSpan elapsed, double powerperc)
+            {
+                //elapsed = TimeSpan.FromSeconds(elapsed.TotalSeconds * 100);
+
+                if (powerperc > 0.03) //do not track any usage under 3% (framing etc)
+                {
+                    TimeSpan normalized = TimeSpan.FromMilliseconds(elapsed.TotalMilliseconds * powerperc); //normalize elapsed time with power
+                    mTimeUsageNormalizedPower = mTimeUsageNormalizedPower + normalized;
+                    mTimeUsageNonZero = mTimeUsageNonZero + elapsed;
+                }
+
+                if (powerperc > 0.01)
+                {
+                    int clx = (int)Math.Floor((powerperc * 100 - 1) / 10); //1-10 = 0, 11-20 = 1; 91-100 = 9
+                    clx = Math.Min(9, Math.Max(0, clx)); //ensure 0-9 range
+                    mTimeClasses[clx] = mTimeClasses[clx] + elapsed;
+                }
+                mLastUsage = DateTime.Today;
+                //System.Diagnostics.Debug.WriteLine($"LT: {mTimeInRun.TotalSeconds} LTT: {mTimeUsageNormalizedPower.TotalSeconds}");
+            }
+
+            internal void Update(LaserLifeCounter selected)
+            {
+                mName = selected.mName;
+                mPurchaseDate = selected.mPurchaseDate;
+                mDeathDate = selected.mDeathDate;
+                mModuleModel = selected.mModuleModel;
+                mBrand = selected.mBrand;
+                mOpticalPower = selected.mOpticalPower;
+            }
+
+            internal bool HasWorked()
+            {
+                return mTimeInRun.TotalHours > 1;
+            }
+
+            void IDeserializationCallback.OnDeserialization(object sender)
+            {
+                if (mTimeClasses == null)
+                    mTimeClasses = new TimeSpan[10];
+            }
+
+            //internal void FixWeirdMeasures()
+            //{
+            //	TimeSpan TT = TimeSpan.Zero;
+            //	foreach (TimeSpan TS in Classes)
+            //		TT = TT.Add(TS);
+
+            //	if (
+            //		LastUsage.HasValue &&
+            //		DateTime.Today < new DateTime(2023, 12, 31) && // smette di farlo ad una certa data
+            //		TimeInRun.TotalHours > 100 && // almeno 100 ore
+            //		TimeInRun.TotalHours > ((LastUsage.Value - MonitoringDate.Value).TotalHours + 24) * 2 && //TIR > 2 * DELTA TRA DATE MONITORATE
+            //		TimeInRun.TotalHours > TT.TotalHours * 100 //TIR > 100 volte Classes.Time
+            //		)
+            //		mTimeInRun = TimeSpan.FromHours(TT.TotalHours * 1.5); //ri-assegna da TT (total time preso dalle classi) esteso * 1.5
+            //}
+        }
+
+        static LaserLifeHandler()
+        {
+            if (mLLCL == null)
+            {
+                mLLCFileName = System.IO.Path.Combine(GrblCore.DataPath, "LaserLifeCounter.bin");
+                mLLCL = Serializer.ObjFromFile(mLLCFileName) as ListLLC;
+                if (mLLCL == null) mLLCL = Serializer.ObjFromFile(mLLCFileName + ".old") as ListLLC;
+
+                if (mLLCL == null) mLLCL = new ListLLC();
+                if (mLLCL.Count == 0) mLLCL.Add(LaserLifeCounter.CreateDefault());
+
+                //mLLCL.FixWeirdMeasures();
+            }
+        }
+
+        public static void ComputeLaserTime(GrblCore.MacStatus status)
+        {
+            try
+            {
+                lock (mLLCL)
+                {
+                    long now = HiResTimer.TotalNano;
+                    if (mLastStatusHiResTimeNano != null)
+                    {
+                        long delta = now - mLastPowerHiResTimeNano.Value;
+                        if (delta > 0 && delta < 600000000000L) //do not add delta if bigger then 600s (or negative) - just a safety test
+                        {
+                            double perc = status == MacStatus.Run ? 1 : 0; //potenza da applicare a questo delta
+                            double normal = delta * perc;
+                            mCurrentLLC?.AddRunTime(TimeSpan.FromMilliseconds(normal / 1000 / 1000));
+                        }
+                    }
+                    mLastStatusHiResTimeNano = now;
+                }
+                SendAndSave();
+            }
+            catch { }
+        }
+
+        private static void SendAndSave()
+        {
+            DoSend();
+            DoSave();
+        }
+
+        public static void ComputeLaserTrueTime(float power)
+        {
+            try
+            {
+                lock (mLLCL)
+                {
+                    long now = HiResTimer.TotalNano;
+                    if (mLastPowerHiResTimeNano != null)
+                    {
+                        long delta = now - mLastPowerHiResTimeNano.Value;
+                        if (delta > 0 && delta < 600000000000L) //do not add delta if bigger then 600s (or negative) - just a safety test
+                        {
+                            decimal maxpwm = Configuration.MaxPWM;
+
+                            if (maxpwm >= 10 && maxpwm <= 100000) //we have a configured value in a valid range
+                            {
+                                double powerperc = Math.Max(0, Math.Min(1, (double)power / (double)maxpwm)); //potenza da applicare a questo delta
+                                mCurrentLLC?.AddTrueLaserTimePower(TimeSpan.FromMilliseconds((double)delta / 1000000.0), powerperc);
+                            }
+                        }
+                    }
+                    mLastPowerHiResTimeNano = now;
+                }
+                SendAndSave();
+            }
+            catch { }
+        }
+
+        public static void OnConnect(Form parent)
+        {
+            try
+            {
+                List<LaserLifeCounter> alive = mLLCL.Where(l => !l.DeathDate.HasValue).ToList();
+                List<LaserLifeCounter> death = mLLCL.Where(l => !l.DeathDate.HasValue).ToList();
+
+                if (mLLCL.Count == 0)           //non ce ne sono... non tracciamo
+                    mCurrentLLC = null;
+                if (mLLCL.Count == 1)           //se ne abbiamo uno solo è per forza lui, vivo o morto che sia
+                    mCurrentLLC = mLLCL[0];
+                else if (alive.Count == 1)      //se ne abbiamo più di uno, ma uno solo è vivo => è per forza lui 
+                    mCurrentLLC = alive[0];
+                else
+                {
+                    string selguid = LaserSelector.CreateAndShowDialog(parent);
+                    mCurrentLLC = mLLCL.First(l => l.Guid == selguid);
+                }
+            }
+            catch { mCurrentLLC = null; }
+
+            Settings.SetObject("Last laser used", mCurrentLLC != null ? mCurrentLLC.Guid : null);
+        }
+
+        internal static void OnDisconnect()
+        {
+            mCurrentLLC = null;
+        }
+
+        private static void DoSave()
+        {
+            try
+            {
+                lock (mLLCFileName)
+                {
+                    long now = HiResTimer.TotalMilliseconds;
+                    if (mLastSave == 0 || now - mLastSave > 20000) //save every 20s
+                    {
+                        ListLLC tosave = GetListClone();
+                        System.Threading.ThreadPool.QueueUserWorkItem(new System.Threading.WaitCallback(RealDoSave), tosave);
+                        mLastSave = now;
+                    }
+                }
+            }
+            catch { }
+        }
+
+        private static void DoSend()
+        {
+            try
+            {
+                DateTime now = DateTime.Now;
+                bool sendnow = false;
+                lock (mLLCL)
+                {
+                    if ((now - mLLCL.LastSent).TotalDays > 14 && (now - mLLCL.LastAttempt).TotalDays > 1)
+                    {
+                        mLLCL.LastAttempt = now;
+                        sendnow = true;
+                    }
+                }
+
+                if (sendnow)
+                {
+                    ListLLC tosend = GetListClone();
+                    System.Threading.ThreadPool.QueueUserWorkItem(new System.Threading.WaitCallback(RealDoSend), tosend);
+                }
+            }
+            catch { }
+        }
+
+        public static ListLLC GetListClone()
+        {
+            return mLLCL?.GetClone();
+        }
+
+        public static void SaveNow()
+        {
+            try { RealDoSave(GetListClone()); }
+            catch { }
+        }
+
+        private static void RealDoSend(object state)
+        {
+            try
+            {
+                List<LaserLifeCounter> tosave = (state as ListLLC).Where(t => t.HasWorked()).ToList();
+                if (UrlManager.LaserStatistics != null && tosave.Count > 0)
+                {
+                    string urlAddress = UrlManager.LaserStatistics;
+                    using (UsageStats.MyWebClient client = new UsageStats.MyWebClient())
+                    {
+                        System.Collections.Specialized.NameValueCollection postData = new System.Collections.Specialized.NameValueCollection()
+                        {
+                            { "version" , "2" },
+                            { "guid", UsageStats.GetID() },
+                            { "data", BuildJson(tosave) },
+                        };
+
+                        // client.UploadValues returns page's source as byte array (byte[]) so it must be transformed into a string
+                        string json = System.Text.Encoding.UTF8.GetString(client.UploadValues(urlAddress, postData));
+
+                        //RealDoSendRV RV = Tools.JSONParser.FromJson<RealDoSendRV>(json);
+                        if (json == "Success!")
+                            mLLCL.LastSent = DateTime.Now;
+                    }
+                }
+
+            }
+            catch { }
+        }
+
+        private static string BuildJson(List<LaserLifeCounter> tosend)
+        {
+            //return "[ { \"id\": \"5001\", \"type\": \"None\" }, { \"id\": \"5004\", \"type\": \"Maple\" } ]";
+
+            System.Text.StringBuilder sb = new System.Text.StringBuilder();
+            sb.Append("[ ");
+
+
+
+            for (int i = 0; i < tosend.Count; i++)
+            {
+                LaserLifeCounter LLC = tosend[i];
+
+                sb.Append("{ ");
+
+                sb.Append($"\"Guid\": {EscapeJson(LLC.Guid)},");
+                sb.Append($"\"Name\": {EscapeJson(LLC.Name)},");
+                sb.Append($"\"Brand\": {EscapeJson(LLC.Brand)},");
+                sb.Append($"\"Model\": {EscapeJson(LLC.Model)},");
+                sb.Append($"\"OpticalPower\": {EscapeJson(LLC.OpticalPower)},");
+                sb.Append($"\"PurchaseDate\": {EscapeJson(LLC.PurchaseDate?.ToString("yyyy-MM-dd HH:mm:ss"))},");
+                sb.Append($"\"MonitoringDate\": {EscapeJson(LLC.MonitoringDate?.ToString("yyyy-MM-dd HH:mm:ss"))},");
+                sb.Append($"\"DeathDate\": {EscapeJson(LLC.DeathDate?.ToString("yyyy-MM-dd HH:mm:ss"))},");
+                sb.Append($"\"LastUsage\": {EscapeJson(LLC.LastUsage?.ToString("yyyy-MM-dd HH:mm:ss"))},");
+                sb.Append($"\"TimeInRun\": {EscapeJson(LLC.TimeInRun.TotalHours)},");
+                sb.Append($"\"TimeUsageNormalizedPower\": {EscapeJson(LLC.TimeUsageNormalizedPower.TotalHours)},");
+                sb.Append($"\"AveragePowerFactor\": {EscapeJson(LLC.AveragePowerFactor)},");
+
+                sb.Append($"\"Classes\": ");
+                {
+                    sb.Append("{ ");
+
+                    for (int j = 0; j < LLC.Classes.Length; j++)
+                    {
+                        sb.Append($"{LLC.Classes[j].TotalHours.ToString("0.000", NumberFormatInfo.InvariantInfo)}");
+
+                        if (j == LLC.Classes.Length - 1) //ultimo
+                            sb.Append(" } ");
+                        else
+                            sb.Append(", ");
+
+                    }
+                }
+
+                if (i == tosend.Count - 1) //ultimo
+                    sb.Append(" } ");
+                else
+                    sb.Append(" }, ");
+            }
+
+            sb.Append(" ]");
+            return sb.ToString();
+        }
+
+        static string EscapeJson(object o)
+        {
+            if (o is double?)
+                return $"\"{(o as double?).GetValueOrDefault().ToString("0.000", NumberFormatInfo.InvariantInfo)}\"";
+            else if (o is double)
+                return $"\"{((double)o).ToString("0.000", NumberFormatInfo.InvariantInfo)}\"";
+            else
+                return HttpUtility.JavaScriptStringEncode(o != null ? o.ToString() : "", true);
+        }
+
+        public class RealDoSendRV
+        {
+            public int UpdateResult = -1;
+
+            [IgnoreDataMember] public bool Success => UpdateResult == 1;
+        }
+
+        private static void RealDoSave(object state)
+        {
+            try
+            {
+                lock (mLLCFileName)
+                {
+                    ListLLC tosave = state as ListLLC;
+                    if (tosave != null)
+                    {
+                        try
+                        {
+                            if (System.IO.File.Exists(mLLCFileName))
+                            {
+                                if (System.IO.File.Exists(mLLCFileName + ".old"))
+                                    System.IO.File.Delete(mLLCFileName + ".old");
+                                System.IO.File.Move(mLLCFileName, mLLCFileName + ".old");
+                            }
+                        }
+                        catch { }
+
+                        try
+                        {
+                            if (System.IO.File.Exists(mLLCFileName))
+                                System.IO.File.Delete(mLLCFileName);
+                        }
+                        catch { }
+
+                        Serializer.ObjToFile(tosave, mLLCFileName);
+                    }
+                }
+            }
+            catch { }
+        }
+
+        internal static TimeSpan GetCurrentTime()
+        {
+            return mCurrentLLC != null ? mCurrentLLC.TimeInRun : TimeSpan.Zero;
+        }
+
+        internal static void Add(LaserLifeCounter llc)
+        {
+            lock (mLLCL)
+            {
+                mLLCL.Add(llc);
+                SaveNow();
+            }
+        }
+
+        internal static void Edit(LaserLifeCounter selected)
+        {
+            lock (mLLCL)
+            {
+                foreach (LaserLifeCounter llc in mLLCL)
+                {
+                    if (llc.Guid == selected.Guid)
+                        llc.Update(selected);
+                }
+                SaveNow();
+            }
+        }
+
+        internal static string Delete(LaserLifeCounter selected)
+        {
+            lock (mLLCL)
+            {
+                if (mCurrentLLC != null && selected.Guid == mCurrentLLC.Guid)
+                    return "You cannot delete currently connected Laser module!";
+
+                mLLCL.RemoveAll(l => l.Guid == selected.Guid);
+                SaveNow();
+                return null;
+            }
+        }
+
+        internal static void Death(LaserLifeCounter selected)
+        {
+            lock (mLLCL)
+            {
+                foreach (LaserLifeCounter llc in mLLCL)
+                {
+                    if (llc.Guid == selected.Guid && llc.DeathDate == null)
+                        llc.DeathDate = DateTime.Today;
+                }
+                SaveNow();
+            }
+        }
+
+        internal static void UnDeath(LaserLifeCounter selected)
+        {
+            lock (mLLCL)
+            {
+                foreach (LaserLifeCounter llc in mLLCL)
+                {
+                    if (llc.Guid == selected.Guid && llc.DeathDate != null)
+                        llc.DeathDate = null;
+                }
+                SaveNow();
+            }
+        }
+    }
 }
 
 /*

--- a/LaserGRBL/CustomButton.cs
+++ b/LaserGRBL/CustomButton.cs
@@ -6,7 +6,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Text;
 
 namespace LaserGRBL
 {
@@ -45,9 +44,8 @@ namespace LaserGRBL
 			CustomButton item = buttons[oldindex];
 			buttons.RemoveAt(oldindex);
 			if(oldindex < newindex && newindex > 0)
-			{
 				newindex--; // removing the element from the list, has impact on the index
-			}
+
 			if (newindex < 0 || newindex > buttons.Count)
 				buttons.Add(item);
 			else
@@ -69,8 +67,7 @@ namespace LaserGRBL
 		{
 			if (buttons != null && buttons.Count > index)
 				return buttons[index];
-			else
-				return null;
+			return null;
 		}
 
 		public static void Export(System.Windows.Forms.Form parent)
@@ -154,7 +151,7 @@ namespace LaserGRBL
 			return false;
 		}
 
-		public static int Count { get { return buttons.Count; } }
+		public static int Count => buttons.Count;
 	}
 
 
@@ -162,7 +159,7 @@ namespace LaserGRBL
 	public class CustomButton
 	{
 		public enum EnableStyles { Always = 0, Connected = 1, Idle = 3, Run = 4, IdleProgram = 10}
-		public enum ButtonTypes { Button = 0, TwoStateButton = 1, PushButton =2 }
+		public enum ButtonTypes { Button = 0, TwoStateButton = 1, PushButton = 2 }
 
 		public System.Guid guid = Guid.NewGuid();
 		public System.Drawing.Image Image;
@@ -170,21 +167,26 @@ namespace LaserGRBL
 		public string GCode2;
 		public string Caption;
 		public string ToolTip;
+		public string HotKeyName;
 
-		public EnableStyles EnableStyle;
+        public EnableStyles EnableStyle;
 		public ButtonTypes ButtonType;
 
 		public bool EnabledNow(GrblCore core)
 		{
 			if (EnableStyle == EnableStyles.Always)
 				return true;
-			else if (EnableStyle == EnableStyles.Connected)
+
+			if (EnableStyle == EnableStyles.Connected)
 				return core.IsConnected;
-			else if (EnableStyle == EnableStyles.Idle)
+
+			if (EnableStyle == EnableStyles.Idle)
 				return core.MachineStatus == GrblCore.MacStatus.Idle;
-			else if (EnableStyle == EnableStyles.Run)
+
+			if (EnableStyle == EnableStyles.Run)
 				return core.MachineStatus == GrblCore.MacStatus.Run;
-			else if (EnableStyle == EnableStyles.IdleProgram)
+
+			if (EnableStyle == EnableStyles.IdleProgram)
 				return core.MachineStatus == GrblCore.MacStatus.Idle && core.HasProgram;
 
 			return false;

--- a/LaserGRBL/CustomButtonForm.Designer.cs
+++ b/LaserGRBL/CustomButtonForm.Designer.cs
@@ -28,202 +28,216 @@
 		/// </summary>
 		private void InitializeComponent()
 		{
-			System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(CustomButtonForm));
-			this.tableLayoutPanel9 = new System.Windows.Forms.TableLayoutPanel();
-			this.tableLayoutPanel1 = new System.Windows.Forms.TableLayoutPanel();
-			this.BtnCancel = new System.Windows.Forms.Button();
-			this.BtnCreate = new System.Windows.Forms.Button();
-			this.tableLayoutPanel2 = new System.Windows.Forms.TableLayoutPanel();
-			this.LblImage = new System.Windows.Forms.Label();
-			this.BTOpenImage = new LaserGRBL.UserControls.ImageButton();
-			this.LblToolTip = new System.Windows.Forms.Label();
-			this.TbToolTip = new System.Windows.Forms.TextBox();
-			this.LblEnabled = new System.Windows.Forms.Label();
-			this.CbEStyles = new System.Windows.Forms.ComboBox();
-			this.LblDescription = new System.Windows.Forms.LinkLabel();
-			this.LblType = new System.Windows.Forms.Label();
-			this.CbByttonType = new System.Windows.Forms.ComboBox();
-			this.tableLayoutPanel3 = new System.Windows.Forms.TableLayoutPanel();
-			this.LblGCode2 = new System.Windows.Forms.Label();
-			this.TBGCode = new System.Windows.Forms.TextBox();
-			this.LblGCode = new System.Windows.Forms.Label();
-			this.TBGCode2 = new System.Windows.Forms.TextBox();
-			this.TbCaption = new System.Windows.Forms.TextBox();
-			this.LblCaption = new System.Windows.Forms.Label();
-			this.tableLayoutPanel9.SuspendLayout();
-			this.tableLayoutPanel1.SuspendLayout();
-			this.tableLayoutPanel2.SuspendLayout();
-			this.tableLayoutPanel3.SuspendLayout();
-			this.SuspendLayout();
-			// 
-			// tableLayoutPanel9
-			// 
-			resources.ApplyResources(this.tableLayoutPanel9, "tableLayoutPanel9");
-			this.tableLayoutPanel9.Controls.Add(this.tableLayoutPanel1, 0, 3);
-			this.tableLayoutPanel9.Controls.Add(this.tableLayoutPanel2, 0, 2);
-			this.tableLayoutPanel9.Name = "tableLayoutPanel9";
-			// 
-			// tableLayoutPanel1
-			// 
-			resources.ApplyResources(this.tableLayoutPanel1, "tableLayoutPanel1");
-			this.tableLayoutPanel1.Controls.Add(this.BtnCancel, 1, 0);
-			this.tableLayoutPanel1.Controls.Add(this.BtnCreate, 2, 0);
-			this.tableLayoutPanel1.Name = "tableLayoutPanel1";
-			// 
-			// BtnCancel
-			// 
-			this.BtnCancel.DialogResult = System.Windows.Forms.DialogResult.Cancel;
-			resources.ApplyResources(this.BtnCancel, "BtnCancel");
-			this.BtnCancel.Name = "BtnCancel";
-			this.BtnCancel.UseVisualStyleBackColor = true;
-			this.BtnCancel.Click += new System.EventHandler(this.BtnCancel_Click);
-			// 
-			// BtnCreate
-			// 
-			resources.ApplyResources(this.BtnCreate, "BtnCreate");
-			this.BtnCreate.Name = "BtnCreate";
-			this.BtnCreate.UseVisualStyleBackColor = true;
-			this.BtnCreate.Click += new System.EventHandler(this.BtnCreate_Click);
-			// 
-			// tableLayoutPanel2
-			// 
-			resources.ApplyResources(this.tableLayoutPanel2, "tableLayoutPanel2");
-			this.tableLayoutPanel2.Controls.Add(this.LblImage, 0, 1);
-			this.tableLayoutPanel2.Controls.Add(this.BTOpenImage, 0, 2);
-			this.tableLayoutPanel2.Controls.Add(this.LblToolTip, 0, 5);
-			this.tableLayoutPanel2.Controls.Add(this.TbToolTip, 1, 5);
-			this.tableLayoutPanel2.Controls.Add(this.LblEnabled, 0, 6);
-			this.tableLayoutPanel2.Controls.Add(this.CbEStyles, 1, 6);
-			this.tableLayoutPanel2.Controls.Add(this.LblDescription, 0, 7);
-			this.tableLayoutPanel2.Controls.Add(this.LblType, 0, 0);
-			this.tableLayoutPanel2.Controls.Add(this.CbByttonType, 1, 0);
-			this.tableLayoutPanel2.Controls.Add(this.tableLayoutPanel3, 1, 1);
-			this.tableLayoutPanel2.Controls.Add(this.TbCaption, 1, 4);
-			this.tableLayoutPanel2.Controls.Add(this.LblCaption, 0, 4);
-			this.tableLayoutPanel2.Name = "tableLayoutPanel2";
-			// 
-			// LblImage
-			// 
-			resources.ApplyResources(this.LblImage, "LblImage");
-			this.LblImage.Name = "LblImage";
-			// 
-			// BTOpenImage
-			// 
-			this.BTOpenImage.AltImage = null;
-			this.BTOpenImage.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(0)))), ((int)(((byte)(0)))), ((int)(((byte)(0)))), ((int)(((byte)(0)))));
-			this.BTOpenImage.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
-			this.BTOpenImage.Caption = "";
-			this.BTOpenImage.Coloration = System.Drawing.Color.Empty;
-			this.BTOpenImage.Image = ((System.Drawing.Image)(resources.GetObject("BTOpenImage.Image")));
-			resources.ApplyResources(this.BTOpenImage, "BTOpenImage");
-			this.BTOpenImage.Name = "BTOpenImage";
-			this.BTOpenImage.SizingMode = LaserGRBL.UserControls.ImageButton.SizingModes.FixedSize;
-			this.BTOpenImage.TabStop = false;
-			this.BTOpenImage.UseAltImage = false;
-			this.BTOpenImage.Click += new System.EventHandler(this.BTOpenImage_Click);
-			// 
-			// LblToolTip
-			// 
-			resources.ApplyResources(this.LblToolTip, "LblToolTip");
-			this.LblToolTip.Name = "LblToolTip";
-			// 
-			// TbToolTip
-			// 
-			resources.ApplyResources(this.TbToolTip, "TbToolTip");
-			this.TbToolTip.Name = "TbToolTip";
-			// 
-			// LblEnabled
-			// 
-			resources.ApplyResources(this.LblEnabled, "LblEnabled");
-			this.LblEnabled.Name = "LblEnabled";
-			// 
-			// CbEStyles
-			// 
-			resources.ApplyResources(this.CbEStyles, "CbEStyles");
-			this.CbEStyles.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-			this.CbEStyles.FormattingEnabled = true;
-			this.CbEStyles.Name = "CbEStyles";
-			// 
-			// LblDescription
-			// 
-			resources.ApplyResources(this.LblDescription, "LblDescription");
-			this.tableLayoutPanel2.SetColumnSpan(this.LblDescription, 2);
-			this.LblDescription.Name = "LblDescription";
-			this.LblDescription.TabStop = true;
-			this.LblDescription.Tag = "https://lasergrbl.com/usage/custom-buttons/";
-			this.LblDescription.UseCompatibleTextRendering = true;
-			this.LblDescription.LinkClicked += new System.Windows.Forms.LinkLabelLinkClickedEventHandler(this.LblDescription_LinkClicked);
-			// 
-			// LblType
-			// 
-			resources.ApplyResources(this.LblType, "LblType");
-			this.LblType.Name = "LblType";
-			// 
-			// CbByttonType
-			// 
-			resources.ApplyResources(this.CbByttonType, "CbByttonType");
-			this.CbByttonType.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-			this.CbByttonType.FormattingEnabled = true;
-			this.CbByttonType.Name = "CbByttonType";
-			this.CbByttonType.SelectedIndexChanged += new System.EventHandler(this.CbByttonType_SelectedIndexChanged);
-			// 
-			// tableLayoutPanel3
-			// 
-			resources.ApplyResources(this.tableLayoutPanel3, "tableLayoutPanel3");
-			this.tableLayoutPanel3.Controls.Add(this.LblGCode2, 1, 0);
-			this.tableLayoutPanel3.Controls.Add(this.TBGCode, 0, 1);
-			this.tableLayoutPanel3.Controls.Add(this.LblGCode, 0, 0);
-			this.tableLayoutPanel3.Controls.Add(this.TBGCode2, 1, 1);
-			this.tableLayoutPanel3.Name = "tableLayoutPanel3";
-			this.tableLayoutPanel2.SetRowSpan(this.tableLayoutPanel3, 2);
-			// 
-			// LblGCode2
-			// 
-			resources.ApplyResources(this.LblGCode2, "LblGCode2");
-			this.LblGCode2.Name = "LblGCode2";
-			// 
-			// TBGCode
-			// 
-			resources.ApplyResources(this.TBGCode, "TBGCode");
-			this.TBGCode.Name = "TBGCode";
-			// 
-			// LblGCode
-			// 
-			resources.ApplyResources(this.LblGCode, "LblGCode");
-			this.LblGCode.Name = "LblGCode";
-			// 
-			// TBGCode2
-			// 
-			resources.ApplyResources(this.TBGCode2, "TBGCode2");
-			this.TBGCode2.Name = "TBGCode2";
-			// 
-			// TbCaption
-			// 
-			resources.ApplyResources(this.TbCaption, "TbCaption");
-			this.TbCaption.Name = "TbCaption";
-			// 
-			// LblCaption
-			// 
-			resources.ApplyResources(this.LblCaption, "LblCaption");
-			this.LblCaption.Name = "LblCaption";
-			// 
-			// CustomButtonForm
-			// 
-			resources.ApplyResources(this, "$this");
-			this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-			this.CancelButton = this.BtnCancel;
-			this.Controls.Add(this.tableLayoutPanel9);
-			this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedToolWindow;
-			this.Name = "CustomButtonForm";
-			this.tableLayoutPanel9.ResumeLayout(false);
-			this.tableLayoutPanel9.PerformLayout();
-			this.tableLayoutPanel1.ResumeLayout(false);
-			this.tableLayoutPanel2.ResumeLayout(false);
-			this.tableLayoutPanel2.PerformLayout();
-			this.tableLayoutPanel3.ResumeLayout(false);
-			this.tableLayoutPanel3.PerformLayout();
-			this.ResumeLayout(false);
-			this.PerformLayout();
+            System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(CustomButtonForm));
+            this.tableLayoutPanel9 = new System.Windows.Forms.TableLayoutPanel();
+            this.tableLayoutPanel1 = new System.Windows.Forms.TableLayoutPanel();
+            this.BtnCancel = new System.Windows.Forms.Button();
+            this.BtnCreate = new System.Windows.Forms.Button();
+            this.tableLayoutPanel2 = new System.Windows.Forms.TableLayoutPanel();
+            this.TbHotKeyName = new System.Windows.Forms.TextBox();
+            this.lblHotKeyName = new System.Windows.Forms.Label();
+            this.LblImage = new System.Windows.Forms.Label();
+            this.BTOpenImage = new LaserGRBL.UserControls.ImageButton();
+            this.LblToolTip = new System.Windows.Forms.Label();
+            this.TbToolTip = new System.Windows.Forms.TextBox();
+            this.LblEnabled = new System.Windows.Forms.Label();
+            this.CbEStyles = new System.Windows.Forms.ComboBox();
+            this.LblType = new System.Windows.Forms.Label();
+            this.CbByttonType = new System.Windows.Forms.ComboBox();
+            this.tableLayoutPanel3 = new System.Windows.Forms.TableLayoutPanel();
+            this.LblGCode2 = new System.Windows.Forms.Label();
+            this.TBGCode = new System.Windows.Forms.TextBox();
+            this.LblGCode = new System.Windows.Forms.Label();
+            this.TBGCode2 = new System.Windows.Forms.TextBox();
+            this.TbCaption = new System.Windows.Forms.TextBox();
+            this.LblCaption = new System.Windows.Forms.Label();
+            this.LblDescription = new System.Windows.Forms.LinkLabel();
+            this.tableLayoutPanel9.SuspendLayout();
+            this.tableLayoutPanel1.SuspendLayout();
+            this.tableLayoutPanel2.SuspendLayout();
+            this.tableLayoutPanel3.SuspendLayout();
+            this.SuspendLayout();
+            // 
+            // tableLayoutPanel9
+            // 
+            resources.ApplyResources(this.tableLayoutPanel9, "tableLayoutPanel9");
+            this.tableLayoutPanel9.Controls.Add(this.tableLayoutPanel1, 0, 3);
+            this.tableLayoutPanel9.Controls.Add(this.tableLayoutPanel2, 0, 2);
+            this.tableLayoutPanel9.Name = "tableLayoutPanel9";
+            // 
+            // tableLayoutPanel1
+            // 
+            resources.ApplyResources(this.tableLayoutPanel1, "tableLayoutPanel1");
+            this.tableLayoutPanel1.Controls.Add(this.BtnCancel, 1, 0);
+            this.tableLayoutPanel1.Controls.Add(this.BtnCreate, 2, 0);
+            this.tableLayoutPanel1.Name = "tableLayoutPanel1";
+            // 
+            // BtnCancel
+            // 
+            this.BtnCancel.DialogResult = System.Windows.Forms.DialogResult.Cancel;
+            resources.ApplyResources(this.BtnCancel, "BtnCancel");
+            this.BtnCancel.Name = "BtnCancel";
+            this.BtnCancel.UseVisualStyleBackColor = true;
+            this.BtnCancel.Click += new System.EventHandler(this.BtnCancel_Click);
+            // 
+            // BtnCreate
+            // 
+            resources.ApplyResources(this.BtnCreate, "BtnCreate");
+            this.BtnCreate.Name = "BtnCreate";
+            this.BtnCreate.UseVisualStyleBackColor = true;
+            this.BtnCreate.Click += new System.EventHandler(this.BtnCreate_Click);
+            // 
+            // tableLayoutPanel2
+            // 
+            resources.ApplyResources(this.tableLayoutPanel2, "tableLayoutPanel2");
+            this.tableLayoutPanel2.Controls.Add(this.TbHotKeyName, 0, 8);
+            this.tableLayoutPanel2.Controls.Add(this.lblHotKeyName, 0, 8);
+            this.tableLayoutPanel2.Controls.Add(this.LblImage, 0, 1);
+            this.tableLayoutPanel2.Controls.Add(this.BTOpenImage, 0, 2);
+            this.tableLayoutPanel2.Controls.Add(this.LblToolTip, 0, 5);
+            this.tableLayoutPanel2.Controls.Add(this.TbToolTip, 1, 5);
+            this.tableLayoutPanel2.Controls.Add(this.LblEnabled, 0, 6);
+            this.tableLayoutPanel2.Controls.Add(this.CbEStyles, 1, 6);
+            this.tableLayoutPanel2.Controls.Add(this.LblType, 0, 0);
+            this.tableLayoutPanel2.Controls.Add(this.CbByttonType, 1, 0);
+            this.tableLayoutPanel2.Controls.Add(this.tableLayoutPanel3, 1, 1);
+            this.tableLayoutPanel2.Controls.Add(this.TbCaption, 1, 4);
+            this.tableLayoutPanel2.Controls.Add(this.LblCaption, 0, 4);
+            this.tableLayoutPanel2.Controls.Add(this.LblDescription, 0, 9);
+            this.tableLayoutPanel2.Name = "tableLayoutPanel2";
+            // 
+            // TbHotKeyName
+            // 
+            resources.ApplyResources(this.TbHotKeyName, "TbHotKeyName");
+            this.TbHotKeyName.Name = "TbHotKeyName";
+            // 
+            // lblHotKeyName
+            // 
+            resources.ApplyResources(this.lblHotKeyName, "lblHotKeyName");
+            this.lblHotKeyName.Name = "lblHotKeyName";
+            // 
+            // LblImage
+            // 
+            resources.ApplyResources(this.LblImage, "LblImage");
+            this.LblImage.Name = "LblImage";
+            // 
+            // BTOpenImage
+            // 
+            this.BTOpenImage.AltImage = null;
+            this.BTOpenImage.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(0)))), ((int)(((byte)(0)))), ((int)(((byte)(0)))), ((int)(((byte)(0)))));
+            this.BTOpenImage.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
+            this.BTOpenImage.Caption = "";
+            this.BTOpenImage.Coloration = System.Drawing.Color.Empty;
+            this.BTOpenImage.Image = ((System.Drawing.Image)(resources.GetObject("BTOpenImage.Image")));
+            resources.ApplyResources(this.BTOpenImage, "BTOpenImage");
+            this.BTOpenImage.Name = "BTOpenImage";
+            this.BTOpenImage.SizingMode = LaserGRBL.UserControls.ImageButton.SizingModes.FixedSize;
+            this.BTOpenImage.TabStop = false;
+            this.BTOpenImage.UseAltImage = false;
+            this.BTOpenImage.Click += new System.EventHandler(this.BTOpenImage_Click);
+            // 
+            // LblToolTip
+            // 
+            resources.ApplyResources(this.LblToolTip, "LblToolTip");
+            this.LblToolTip.Name = "LblToolTip";
+            // 
+            // TbToolTip
+            // 
+            resources.ApplyResources(this.TbToolTip, "TbToolTip");
+            this.TbToolTip.Name = "TbToolTip";
+            // 
+            // LblEnabled
+            // 
+            resources.ApplyResources(this.LblEnabled, "LblEnabled");
+            this.LblEnabled.Name = "LblEnabled";
+            // 
+            // CbEStyles
+            // 
+            resources.ApplyResources(this.CbEStyles, "CbEStyles");
+            this.CbEStyles.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.CbEStyles.FormattingEnabled = true;
+            this.CbEStyles.Name = "CbEStyles";
+            // 
+            // LblType
+            // 
+            resources.ApplyResources(this.LblType, "LblType");
+            this.LblType.Name = "LblType";
+            // 
+            // CbByttonType
+            // 
+            resources.ApplyResources(this.CbByttonType, "CbByttonType");
+            this.CbByttonType.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.CbByttonType.FormattingEnabled = true;
+            this.CbByttonType.Name = "CbByttonType";
+            this.CbByttonType.SelectedIndexChanged += new System.EventHandler(this.CbByttonType_SelectedIndexChanged);
+            // 
+            // tableLayoutPanel3
+            // 
+            resources.ApplyResources(this.tableLayoutPanel3, "tableLayoutPanel3");
+            this.tableLayoutPanel3.Controls.Add(this.LblGCode2, 1, 0);
+            this.tableLayoutPanel3.Controls.Add(this.TBGCode, 0, 1);
+            this.tableLayoutPanel3.Controls.Add(this.LblGCode, 0, 0);
+            this.tableLayoutPanel3.Controls.Add(this.TBGCode2, 1, 1);
+            this.tableLayoutPanel3.Name = "tableLayoutPanel3";
+            this.tableLayoutPanel2.SetRowSpan(this.tableLayoutPanel3, 2);
+            // 
+            // LblGCode2
+            // 
+            resources.ApplyResources(this.LblGCode2, "LblGCode2");
+            this.LblGCode2.Name = "LblGCode2";
+            // 
+            // TBGCode
+            // 
+            resources.ApplyResources(this.TBGCode, "TBGCode");
+            this.TBGCode.Name = "TBGCode";
+            // 
+            // LblGCode
+            // 
+            resources.ApplyResources(this.LblGCode, "LblGCode");
+            this.LblGCode.Name = "LblGCode";
+            // 
+            // TBGCode2
+            // 
+            resources.ApplyResources(this.TBGCode2, "TBGCode2");
+            this.TBGCode2.Name = "TBGCode2";
+            // 
+            // TbCaption
+            // 
+            resources.ApplyResources(this.TbCaption, "TbCaption");
+            this.TbCaption.Name = "TbCaption";
+            // 
+            // LblCaption
+            // 
+            resources.ApplyResources(this.LblCaption, "LblCaption");
+            this.LblCaption.Name = "LblCaption";
+            // 
+            // LblDescription
+            // 
+            resources.ApplyResources(this.LblDescription, "LblDescription");
+            this.tableLayoutPanel2.SetColumnSpan(this.LblDescription, 2);
+            this.LblDescription.Name = "LblDescription";
+            this.LblDescription.TabStop = true;
+            this.LblDescription.Tag = "https://lasergrbl.com/usage/custom-buttons/";
+            this.LblDescription.UseCompatibleTextRendering = true;
+            this.LblDescription.LinkClicked += new System.Windows.Forms.LinkLabelLinkClickedEventHandler(this.LblDescription_LinkClicked);
+            // 
+            // CustomButtonForm
+            // 
+            resources.ApplyResources(this, "$this");
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.CancelButton = this.BtnCancel;
+            this.Controls.Add(this.tableLayoutPanel9);
+            this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedToolWindow;
+            this.Name = "CustomButtonForm";
+            this.tableLayoutPanel9.ResumeLayout(false);
+            this.tableLayoutPanel9.PerformLayout();
+            this.tableLayoutPanel1.ResumeLayout(false);
+            this.tableLayoutPanel2.ResumeLayout(false);
+            this.tableLayoutPanel2.PerformLayout();
+            this.tableLayoutPanel3.ResumeLayout(false);
+            this.tableLayoutPanel3.PerformLayout();
+            this.ResumeLayout(false);
+            this.PerformLayout();
 
 		}
 
@@ -250,5 +264,7 @@
 		private System.Windows.Forms.TextBox TbCaption;
 		private System.Windows.Forms.Label LblCaption;
         private System.Windows.Forms.LinkLabel LblDescription;
+        private System.Windows.Forms.TextBox TbHotKeyName;
+        private System.Windows.Forms.Label lblHotKeyName;
     }
 }

--- a/LaserGRBL/CustomButtonForm.cs
+++ b/LaserGRBL/CustomButtonForm.cs
@@ -52,6 +52,7 @@ namespace LaserGRBL
 			BTOpenImage.Image = cb.Image;
 			TbCaption.Text = cb.Caption;
 			TbToolTip.Text = cb.ToolTip;
+			TbHotKeyName.Text = cb.HotKeyName;
 			CbEStyles.SelectedItem = cb.EnableStyle;
 			CbByttonType.SelectedItem = cb.ButtonType;
 
@@ -99,6 +100,7 @@ namespace LaserGRBL
 				cb.Image = BTOpenImage.Image;
 				cb.Caption = TbCaption.Text;
 				cb.ToolTip = TbToolTip.Text;
+				cb.HotKeyName = TbHotKeyName.Text;
 				cb.EnableStyle = (CustomButton.EnableStyles)CbEStyles.SelectedItem;
 				CustomButtons.Add(cb);
 			}
@@ -109,7 +111,8 @@ namespace LaserGRBL
 				inedit.Image = BTOpenImage.Image;
 				inedit.Caption = TbCaption.Text;
 				inedit.ToolTip = TbToolTip.Text;
-				inedit.EnableStyle = (CustomButton.EnableStyles)CbEStyles.SelectedItem;
+				inedit.HotKeyName = TbHotKeyName.Text;
+                inedit.EnableStyle = (CustomButton.EnableStyles)CbEStyles.SelectedItem;
 				inedit.ButtonType = (CustomButton.ButtonTypes)CbByttonType.SelectedItem;
 			}
 

--- a/LaserGRBL/CustomButtonForm.resx
+++ b/LaserGRBL/CustomButtonForm.resx
@@ -117,11 +117,11 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <assembly alias="mscorlib" name="mscorlib, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <assembly alias="mscorlib" name="mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="tableLayoutPanel9.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
-  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="tableLayoutPanel9.AutoSizeMode" type="System.Windows.Forms.AutoSizeMode, System.Windows.Forms">
     <value>GrowAndShrink</value>
   </data>
@@ -140,9 +140,9 @@
   <data name="BtnCancel.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
   </data>
-  <assembly alias="System.Drawing" name="System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   <data name="BtnCancel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>234, 3</value>
+    <value>258, 3</value>
   </data>
   <data name="BtnCancel.Size" type="System.Drawing.Size, System.Drawing">
     <value>74, 27</value>
@@ -157,7 +157,7 @@
     <value>BtnCancel</value>
   </data>
   <data name="&gt;&gt;BtnCancel.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;BtnCancel.Parent" xml:space="preserve">
     <value>tableLayoutPanel1</value>
@@ -169,7 +169,7 @@
     <value>NoControl</value>
   </data>
   <data name="BtnCreate.Location" type="System.Drawing.Point, System.Drawing">
-    <value>314, 3</value>
+    <value>338, 3</value>
   </data>
   <data name="BtnCreate.Size" type="System.Drawing.Size, System.Drawing">
     <value>74, 27</value>
@@ -184,7 +184,7 @@
     <value>BtnCreate</value>
   </data>
   <data name="&gt;&gt;BtnCreate.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;BtnCreate.Parent" xml:space="preserve">
     <value>tableLayoutPanel1</value>
@@ -196,13 +196,13 @@
     <value>Fill</value>
   </data>
   <data name="tableLayoutPanel1.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 321</value>
+    <value>3, 349</value>
   </data>
   <data name="tableLayoutPanel1.RowCount" type="System.Int32, mscorlib">
     <value>1</value>
   </data>
   <data name="tableLayoutPanel1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>391, 33</value>
+    <value>415, 33</value>
   </data>
   <data name="tableLayoutPanel1.TabIndex" type="System.Int32, mscorlib">
     <value>2</value>
@@ -211,7 +211,7 @@
     <value>tableLayoutPanel1</value>
   </data>
   <data name="&gt;&gt;tableLayoutPanel1.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TableLayoutPanel, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.TableLayoutPanel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;tableLayoutPanel1.Parent" xml:space="preserve">
     <value>tableLayoutPanel9</value>
@@ -230,6 +230,63 @@
   </data>
   <data name="tableLayoutPanel2.ColumnCount" type="System.Int32, mscorlib">
     <value>2</value>
+  </data>
+  <data name="TbHotKeyName.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Fill</value>
+  </data>
+  <data name="TbHotKeyName.Location" type="System.Drawing.Point, System.Drawing">
+    <value>82, 234</value>
+  </data>
+  <data name="TbHotKeyName.Size" type="System.Drawing.Size, System.Drawing">
+    <value>330, 20</value>
+  </data>
+  <data name="TbHotKeyName.TabIndex" type="System.Int32, mscorlib">
+    <value>27</value>
+  </data>
+  <data name="&gt;&gt;TbHotKeyName.Name" xml:space="preserve">
+    <value>TbHotKeyName</value>
+  </data>
+  <data name="&gt;&gt;TbHotKeyName.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;TbHotKeyName.Parent" xml:space="preserve">
+    <value>tableLayoutPanel2</value>
+  </data>
+  <data name="&gt;&gt;TbHotKeyName.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="lblHotKeyName.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Left</value>
+  </data>
+  <data name="lblHotKeyName.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="lblHotKeyName.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="lblHotKeyName.Location" type="System.Drawing.Point, System.Drawing">
+    <value>3, 238</value>
+  </data>
+  <data name="lblHotKeyName.Size" type="System.Drawing.Size, System.Drawing">
+    <value>73, 13</value>
+  </data>
+  <data name="lblHotKeyName.TabIndex" type="System.Int32, mscorlib">
+    <value>26</value>
+  </data>
+  <data name="lblHotKeyName.Text" xml:space="preserve">
+    <value>HotKey Name</value>
+  </data>
+  <data name="&gt;&gt;lblHotKeyName.Name" xml:space="preserve">
+    <value>lblHotKeyName</value>
+  </data>
+  <data name="&gt;&gt;lblHotKeyName.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblHotKeyName.Parent" xml:space="preserve">
+    <value>tableLayoutPanel2</value>
+  </data>
+  <data name="&gt;&gt;lblHotKeyName.ZOrder" xml:space="preserve">
+    <value>1</value>
   </data>
   <data name="LblImage.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Left</value>
@@ -259,18 +316,18 @@
     <value>LblImage</value>
   </data>
   <data name="&gt;&gt;LblImage.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;LblImage.Parent" xml:space="preserve">
     <value>tableLayoutPanel2</value>
   </data>
   <data name="&gt;&gt;LblImage.ZOrder" xml:space="preserve">
-    <value>0</value>
+    <value>2</value>
   </data>
   <data name="BTOpenImage.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAADAAAAAwCAYAAABXAvmHAAAABGdBTUEAAJxAIA3kywAAACBjSFJNAABu
-        lQAAdA4AAPGBAACFRgAAZO0AAPeGAABJ4gAAHljF0QxvAAAACXBIWXMAAAsTAAALEwEAmpwYAAASq0lE
+        lQAAdA4AAPGBAACFRgAAZO0AAPeGAABJ4gAAHljF0QxvAAAACXBIWXMAAAsRAAALEQF/ZF+RAAASq0lE
         QVRoQ81YB1iUZ9b9jOnr/5tsfo2JMTaCiQr2QkwxakyzxGRjjO6q2Fs0llhiEk2zgDQBESkiqKDBFhVR
         QaQNZWCGafQ6jaEPDB3h7rkfRUw2u/8m6z7hee7zlZn5vnPue+6590VwcfMUnF3dBUcnV8HhV+LgIRfB
         zf2I4O3jJ5jN1UJTU7PQ0ND4q1FdXSN+r7q6WqipqRHSM7I2xsTFZR8/EbSCn3Pk6DGEj3h08/DCs72E
@@ -366,13 +423,13 @@
     <value>BTOpenImage</value>
   </data>
   <data name="&gt;&gt;BTOpenImage.Type" xml:space="preserve">
-    <value>LaserGRBL.UserControls.ImageButton, LaserGRBL, Version=3.3.0.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>LaserGRBL.UserControls.ImageButton, LaserGRBL, Version=5.6.0.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;BTOpenImage.Parent" xml:space="preserve">
     <value>tableLayoutPanel2</value>
   </data>
   <data name="&gt;&gt;BTOpenImage.ZOrder" xml:space="preserve">
-    <value>1</value>
+    <value>3</value>
   </data>
   <data name="LblToolTip.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Left</value>
@@ -399,19 +456,19 @@
     <value>LblToolTip</value>
   </data>
   <data name="&gt;&gt;LblToolTip.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;LblToolTip.Parent" xml:space="preserve">
     <value>tableLayoutPanel2</value>
   </data>
   <data name="&gt;&gt;LblToolTip.ZOrder" xml:space="preserve">
-    <value>2</value>
+    <value>4</value>
   </data>
   <data name="TbToolTip.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
     <value>Fill</value>
   </data>
   <data name="TbToolTip.Location" type="System.Drawing.Point, System.Drawing">
-    <value>58, 181</value>
+    <value>82, 181</value>
   </data>
   <data name="TbToolTip.Size" type="System.Drawing.Size, System.Drawing">
     <value>330, 20</value>
@@ -423,13 +480,13 @@
     <value>TbToolTip</value>
   </data>
   <data name="&gt;&gt;TbToolTip.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;TbToolTip.Parent" xml:space="preserve">
     <value>tableLayoutPanel2</value>
   </data>
   <data name="&gt;&gt;TbToolTip.ZOrder" xml:space="preserve">
-    <value>3</value>
+    <value>5</value>
   </data>
   <data name="LblEnabled.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Left</value>
@@ -456,19 +513,19 @@
     <value>LblEnabled</value>
   </data>
   <data name="&gt;&gt;LblEnabled.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;LblEnabled.Parent" xml:space="preserve">
     <value>tableLayoutPanel2</value>
   </data>
   <data name="&gt;&gt;LblEnabled.ZOrder" xml:space="preserve">
-    <value>4</value>
+    <value>6</value>
   </data>
   <data name="CbEStyles.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Left, Right</value>
   </data>
   <data name="CbEStyles.Location" type="System.Drawing.Point, System.Drawing">
-    <value>58, 207</value>
+    <value>82, 207</value>
   </data>
   <data name="CbEStyles.Size" type="System.Drawing.Size, System.Drawing">
     <value>330, 21</value>
@@ -480,58 +537,13 @@
     <value>CbEStyles</value>
   </data>
   <data name="&gt;&gt;CbEStyles.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;CbEStyles.Parent" xml:space="preserve">
     <value>tableLayoutPanel2</value>
   </data>
   <data name="&gt;&gt;CbEStyles.ZOrder" xml:space="preserve">
-    <value>5</value>
-  </data>
-  <data name="LblDescription.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="LblDescription.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="LblDescription.LinkArea" type="System.Windows.Forms.LinkArea, System.Windows.Forms">
-    <value>192, 238</value>
-  </data>
-  <data name="LblDescription.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 234</value>
-  </data>
-  <data name="LblDescription.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>3, 3, 3, 3</value>
-  </data>
-  <data name="LblDescription.MaximumSize" type="System.Drawing.Size, System.Drawing">
-    <value>400, 0</value>
-  </data>
-  <data name="LblDescription.Size" type="System.Drawing.Size, System.Drawing">
-    <value>381, 80</value>
-  </data>
-  <data name="LblDescription.TabIndex" type="System.Int32, mscorlib">
-    <value>14</value>
-  </data>
-  <data name="LblDescription.Text" xml:space="preserve">
-    <value>- Use dot as decimal separator
-- Support math expression in square brackets: i.e. G0 X[left-5] Y[bottom-5]
-- Available variables: left, right, top, bottom, width, height.. (and more)
-
-See https://lasergrbl.com/usage/custom-buttons/
-
-</value>
-  </data>
-  <data name="&gt;&gt;LblDescription.Name" xml:space="preserve">
-    <value>LblDescription</value>
-  </data>
-  <data name="&gt;&gt;LblDescription.Type" xml:space="preserve">
-    <value>System.Windows.Forms.LinkLabel, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;LblDescription.Parent" xml:space="preserve">
-    <value>tableLayoutPanel2</value>
-  </data>
-  <data name="&gt;&gt;LblDescription.ZOrder" xml:space="preserve">
-    <value>6</value>
+    <value>7</value>
   </data>
   <data name="LblType.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Left</value>
@@ -558,19 +570,19 @@ See https://lasergrbl.com/usage/custom-buttons/
     <value>LblType</value>
   </data>
   <data name="&gt;&gt;LblType.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;LblType.Parent" xml:space="preserve">
     <value>tableLayoutPanel2</value>
   </data>
   <data name="&gt;&gt;LblType.ZOrder" xml:space="preserve">
-    <value>7</value>
+    <value>8</value>
   </data>
   <data name="CbByttonType.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Left, Right</value>
   </data>
   <data name="CbByttonType.Location" type="System.Drawing.Point, System.Drawing">
-    <value>58, 3</value>
+    <value>82, 3</value>
   </data>
   <data name="CbByttonType.Size" type="System.Drawing.Size, System.Drawing">
     <value>330, 21</value>
@@ -582,13 +594,13 @@ See https://lasergrbl.com/usage/custom-buttons/
     <value>CbByttonType</value>
   </data>
   <data name="&gt;&gt;CbByttonType.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;CbByttonType.Parent" xml:space="preserve">
     <value>tableLayoutPanel2</value>
   </data>
   <data name="&gt;&gt;CbByttonType.ZOrder" xml:space="preserve">
-    <value>8</value>
+    <value>9</value>
   </data>
   <data name="tableLayoutPanel3.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -627,7 +639,7 @@ See https://lasergrbl.com/usage/custom-buttons/
     <value>LblGCode2</value>
   </data>
   <data name="&gt;&gt;LblGCode2.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;LblGCode2.Parent" xml:space="preserve">
     <value>tableLayoutPanel3</value>
@@ -654,7 +666,7 @@ See https://lasergrbl.com/usage/custom-buttons/
     <value>TBGCode</value>
   </data>
   <data name="&gt;&gt;TBGCode.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;TBGCode.Parent" xml:space="preserve">
     <value>tableLayoutPanel3</value>
@@ -690,7 +702,7 @@ See https://lasergrbl.com/usage/custom-buttons/
     <value>LblGCode</value>
   </data>
   <data name="&gt;&gt;LblGCode.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;LblGCode.Parent" xml:space="preserve">
     <value>tableLayoutPanel3</value>
@@ -720,7 +732,7 @@ See https://lasergrbl.com/usage/custom-buttons/
     <value>TBGCode2</value>
   </data>
   <data name="&gt;&gt;TBGCode2.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;TBGCode2.Parent" xml:space="preserve">
     <value>tableLayoutPanel3</value>
@@ -732,7 +744,7 @@ See https://lasergrbl.com/usage/custom-buttons/
     <value>Fill</value>
   </data>
   <data name="tableLayoutPanel3.Location" type="System.Drawing.Point, System.Drawing">
-    <value>55, 27</value>
+    <value>79, 27</value>
   </data>
   <data name="tableLayoutPanel3.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>0, 0, 0, 0</value>
@@ -750,13 +762,13 @@ See https://lasergrbl.com/usage/custom-buttons/
     <value>tableLayoutPanel3</value>
   </data>
   <data name="&gt;&gt;tableLayoutPanel3.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TableLayoutPanel, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.TableLayoutPanel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;tableLayoutPanel3.Parent" xml:space="preserve">
     <value>tableLayoutPanel2</value>
   </data>
   <data name="&gt;&gt;tableLayoutPanel3.ZOrder" xml:space="preserve">
-    <value>9</value>
+    <value>10</value>
   </data>
   <data name="tableLayoutPanel3.LayoutSettings" type="System.Windows.Forms.TableLayoutSettings, System.Windows.Forms">
     <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="LblGCode2" Row="0" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="TBGCode" Row="1" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="LblGCode" Row="0" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="TBGCode2" Row="1" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;/Controls&gt;&lt;Columns Styles="Percent,50,Percent,50" /&gt;&lt;Rows Styles="AutoSize,0,AutoSize,0" /&gt;&lt;/TableLayoutSettings&gt;</value>
@@ -765,7 +777,7 @@ See https://lasergrbl.com/usage/custom-buttons/
     <value>Fill</value>
   </data>
   <data name="TbCaption.Location" type="System.Drawing.Point, System.Drawing">
-    <value>58, 155</value>
+    <value>82, 155</value>
   </data>
   <data name="TbCaption.Size" type="System.Drawing.Size, System.Drawing">
     <value>330, 20</value>
@@ -777,13 +789,13 @@ See https://lasergrbl.com/usage/custom-buttons/
     <value>TbCaption</value>
   </data>
   <data name="&gt;&gt;TbCaption.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;TbCaption.Parent" xml:space="preserve">
     <value>tableLayoutPanel2</value>
   </data>
   <data name="&gt;&gt;TbCaption.ZOrder" xml:space="preserve">
-    <value>10</value>
+    <value>11</value>
   </data>
   <data name="LblCaption.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -798,7 +810,7 @@ See https://lasergrbl.com/usage/custom-buttons/
     <value>3, 152</value>
   </data>
   <data name="LblCaption.Size" type="System.Drawing.Size, System.Drawing">
-    <value>49, 26</value>
+    <value>73, 26</value>
   </data>
   <data name="LblCaption.TabIndex" type="System.Int32, mscorlib">
     <value>25</value>
@@ -813,13 +825,58 @@ See https://lasergrbl.com/usage/custom-buttons/
     <value>LblCaption</value>
   </data>
   <data name="&gt;&gt;LblCaption.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;LblCaption.Parent" xml:space="preserve">
     <value>tableLayoutPanel2</value>
   </data>
   <data name="&gt;&gt;LblCaption.ZOrder" xml:space="preserve">
-    <value>11</value>
+    <value>12</value>
+  </data>
+  <data name="LblDescription.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="LblDescription.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="LblDescription.LinkArea" type="System.Windows.Forms.LinkArea, System.Windows.Forms">
+    <value>192, 238</value>
+  </data>
+  <data name="LblDescription.Location" type="System.Drawing.Point, System.Drawing">
+    <value>3, 261</value>
+  </data>
+  <data name="LblDescription.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>3, 3, 3, 3</value>
+  </data>
+  <data name="LblDescription.MaximumSize" type="System.Drawing.Size, System.Drawing">
+    <value>400, 0</value>
+  </data>
+  <data name="LblDescription.Size" type="System.Drawing.Size, System.Drawing">
+    <value>381, 76</value>
+  </data>
+  <data name="LblDescription.TabIndex" type="System.Int32, mscorlib">
+    <value>14</value>
+  </data>
+  <data name="LblDescription.Text" xml:space="preserve">
+    <value>- Use dot as decimal separator
+- Support math expression in square brackets: i.e. G0 X[left-5] Y[bottom-5]
+- Available variables: left, right, top, bottom, width, height.. (and more)
+
+See https://lasergrbl.com/usage/custom-buttons/
+
+</value>
+  </data>
+  <data name="&gt;&gt;LblDescription.Name" xml:space="preserve">
+    <value>LblDescription</value>
+  </data>
+  <data name="&gt;&gt;LblDescription.Type" xml:space="preserve">
+    <value>System.Windows.Forms.LinkLabel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;LblDescription.Parent" xml:space="preserve">
+    <value>tableLayoutPanel2</value>
+  </data>
+  <data name="&gt;&gt;LblDescription.ZOrder" xml:space="preserve">
+    <value>13</value>
   </data>
   <data name="tableLayoutPanel2.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
     <value>Fill</value>
@@ -828,10 +885,10 @@ See https://lasergrbl.com/usage/custom-buttons/
     <value>3, 3</value>
   </data>
   <data name="tableLayoutPanel2.RowCount" type="System.Int32, mscorlib">
-    <value>8</value>
+    <value>10</value>
   </data>
   <data name="tableLayoutPanel2.Size" type="System.Drawing.Size, System.Drawing">
-    <value>391, 312</value>
+    <value>415, 340</value>
   </data>
   <data name="tableLayoutPanel2.TabIndex" type="System.Int32, mscorlib">
     <value>3</value>
@@ -840,7 +897,7 @@ See https://lasergrbl.com/usage/custom-buttons/
     <value>tableLayoutPanel2</value>
   </data>
   <data name="&gt;&gt;tableLayoutPanel2.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TableLayoutPanel, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.TableLayoutPanel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;tableLayoutPanel2.Parent" xml:space="preserve">
     <value>tableLayoutPanel9</value>
@@ -849,7 +906,7 @@ See https://lasergrbl.com/usage/custom-buttons/
     <value>1</value>
   </data>
   <data name="tableLayoutPanel2.LayoutSettings" type="System.Windows.Forms.TableLayoutSettings, System.Windows.Forms">
-    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="LblImage" Row="1" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="BTOpenImage" Row="2" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="LblToolTip" Row="5" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="TbToolTip" Row="5" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="LblEnabled" Row="6" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="CbEStyles" Row="6" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="LblDescription" Row="7" RowSpan="1" Column="0" ColumnSpan="2" /&gt;&lt;Control Name="LblType" Row="0" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="CbByttonType" Row="0" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="tableLayoutPanel3" Row="1" RowSpan="2" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="TbCaption" Row="4" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="LblCaption" Row="4" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;/Controls&gt;&lt;Columns Styles="AutoSize,0,AutoSize,0" /&gt;&lt;Rows Styles="AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,Absolute,20" /&gt;&lt;/TableLayoutSettings&gt;</value>
+    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="TbHotKeyName" Row="8" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="lblHotKeyName" Row="8" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="LblImage" Row="1" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="BTOpenImage" Row="2" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="LblToolTip" Row="5" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="TbToolTip" Row="5" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="LblEnabled" Row="6" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="CbEStyles" Row="6" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="LblType" Row="0" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="CbByttonType" Row="0" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="tableLayoutPanel3" Row="1" RowSpan="2" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="TbCaption" Row="4" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="LblCaption" Row="4" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="LblDescription" Row="9" RowSpan="1" Column="0" ColumnSpan="2" /&gt;&lt;/Controls&gt;&lt;Columns Styles="AutoSize,0,AutoSize,0" /&gt;&lt;Rows Styles="AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,Absolute,27,Absolute,13,Absolute,20" /&gt;&lt;/TableLayoutSettings&gt;</value>
   </data>
   <data name="tableLayoutPanel9.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
     <value>Fill</value>
@@ -861,7 +918,7 @@ See https://lasergrbl.com/usage/custom-buttons/
     <value>4</value>
   </data>
   <data name="tableLayoutPanel9.Size" type="System.Drawing.Size, System.Drawing">
-    <value>397, 357</value>
+    <value>421, 385</value>
   </data>
   <data name="tableLayoutPanel9.TabIndex" type="System.Int32, mscorlib">
     <value>2</value>
@@ -870,7 +927,7 @@ See https://lasergrbl.com/usage/custom-buttons/
     <value>tableLayoutPanel9</value>
   </data>
   <data name="&gt;&gt;tableLayoutPanel9.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TableLayoutPanel, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.TableLayoutPanel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;tableLayoutPanel9.Parent" xml:space="preserve">
     <value>$this</value>
@@ -881,17 +938,17 @@ See https://lasergrbl.com/usage/custom-buttons/
   <data name="tableLayoutPanel9.LayoutSettings" type="System.Windows.Forms.TableLayoutSettings, System.Windows.Forms">
     <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="tableLayoutPanel1" Row="3" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="tableLayoutPanel2" Row="2" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;/Controls&gt;&lt;Columns Styles="AutoSize,0" /&gt;&lt;Rows Styles="AutoSize,0,AutoSize,0,Percent,100,AutoSize,0" /&gt;&lt;/TableLayoutSettings&gt;</value>
   </data>
+  <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
   <data name="$this.AutoScaleDimensions" type="System.Drawing.SizeF, System.Drawing">
     <value>6, 13</value>
   </data>
   <data name="$this.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
-  <data name="$this.AutoSizeMode" type="System.Windows.Forms.AutoSizeMode, System.Windows.Forms">
-    <value>GrowAndShrink</value>
-  </data>
   <data name="$this.ClientSize" type="System.Drawing.Size, System.Drawing">
-    <value>397, 357</value>
+    <value>421, 385</value>
   </data>
   <data name="$this.StartPosition" type="System.Windows.Forms.FormStartPosition, System.Windows.Forms">
     <value>CenterParent</value>
@@ -903,9 +960,6 @@ See https://lasergrbl.com/usage/custom-buttons/
     <value>CustomButtonForm</value>
   </data>
   <data name="&gt;&gt;$this.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Form, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Form, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
 </root>

--- a/LaserGRBL/HotKeysManager.cs
+++ b/LaserGRBL/HotKeysManager.cs
@@ -7,349 +7,339 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using System.Windows.Forms;
 
 namespace LaserGRBL
 {
-	[Serializable]
-	public class HotKeysManager : List<HotKeysManager.HotKey>
-	{
-		[NonSerialized] private GrblCore mCore;
+    [Serializable]
+    public class HotKeysManager : List<HotKeysManager.HotKey>
+    {
+        [NonSerialized] private GrblCore mCore;
         [NonSerialized] private PreviewForm mPreviewForm;
-		[NonSerialized] private JogForm mJogForm;
-		[NonSerialized] List<int> mCustomButtonPressed;
-		[NonSerialized] private bool mJogKeyRequested = false;
+        [NonSerialized] private JogForm mJogForm;
+        [NonSerialized] List<int> mCustomButtonPressed;
+        [NonSerialized] private bool mJogKeyRequested = false;
 
-		[Serializable]
-		public class HotKey : ICloneable
-		{
-			public enum Actions
-			{
-				ConnectDisconnect = 10, Connect = 11, Disconnect = 12,
-				OpenFile = 20, ReopenLastFile = 21, SaveFile = 22, ExecuteFile = 23, AbortFile = 24,
-				HelpOnline = 30,
-				Reset = 100, Homing = 101, Unlock = 102,  PauseJob = 103, ResumeJob = 104, SetNewZero = 105,
-                JogHome = 1000, JogN = 1001, JogNE = 1002, JogE = 1003, JogSE = 1004, JogS = 1005, JogSW = 1006, JogW = 1007, JogNW = 1008, JogUp = 1009, JogDown = 1010,
-				JogStepIncrease = 1020, JogStepDecrease = 1021,
-				JogSpeedIncrease = 1030, JogSpeedDecrease = 1031,
-				OverridePowerDefault = 1100, OverridePowerUp = 1101, OverridePowerDown = 1102,
-				OverrideLinearDefault = 1110, OverrideLinearUp = 1111, OverrideLinearDown = 1112,
-				OverrideRapidDefault = 1120, OverrideRapidUp = 1121, OverrideRapidDown = 1122,
-				CustomButton1 = 2000, CustomButton2 = 2001, CustomButton3 = 2002, CustomButton4 = 2003, CustomButton5 = 2004, CustomButton6 = 2005, CustomButton7 = 2006, CustomButton8 = 2007, CustomButton9 = 2008, CustomButton10 = 2009
-			}
-
-			private Keys mCombination;
-			private Actions mAction;
-
-			public Actions Action
-			{ get { return mAction; } }
-
-			public Keys Combination
-			{ get { return mCombination; } }
-
-			public HotKey(Actions action, Keys keys)
-			{ mAction = action; mCombination = keys; }
-
-			public static bool ValidShortcut(Keys Combination)
-			{
-				Keys control = Keys.None;
-				Keys standard = Keys.None;
-
-				if (Combination != Keys.None)
-				{
-					foreach (Keys x in Enum.GetValues(typeof(Keys)))
-						if ((x & Combination) == x)
-							if (IsStandard(x))
-								standard |= x;
-							else
-								control |= x;
-				}
-
-				return standard != Keys.None;
-			}
-
-			private static bool IsStandard(Keys key)
-			{ return IsLetter(key) || IsNumeric(key) || IsFunction(key); }
-
-			private static bool IsNumeric(Keys key)
-			{return ((key >= Keys.D0 && key <= Keys.D9) || (key >= Keys.NumPad0 && key <= Keys.NumPad9));}
-
-			private static bool IsLetter(Keys key)
-			{return (key >= Keys.A && key <= Keys.Z);}
-
-			private static bool IsFunction(Keys key)
-			{{ return (key >= Keys.F1 && key <= Keys.F24); }}
-
-			private static bool IsModifier(Keys key)
-			{ { return (key & Keys.Modifiers) == key; } }
-
-			internal void SetShortcut(Keys shortcut)
-			{mCombination = shortcut;}
-
-			public object Clone()
-			{
-				return this.MemberwiseClone();
-			}
-		}
-
-		public HotKeysManager()
-		{
-			
-		}
-
-        public void SetCustomButtonToolbar()
+        [Serializable]
+        public class HotKey : ICloneable
         {
+            // built-in Actions that can be assigned to a hotKey
+            public enum Actions
+            {
+                None = 0,
+                ConnectDisconnect = 10, Connect = 11, Disconnect = 12,
+                OpenFile = 20, ReopenLastFile = 21, SaveFile = 22, ExecuteFile = 23, AbortFile = 24,
+                HelpOnline = 30,
+                Reset = 100, Homing = 101, Unlock = 102, PauseJob = 103, ResumeJob = 104, SetNewZero = 105,
+                JogHome = 1000, JogN = 1001, JogNE = 1002, JogE = 1003, JogSE = 1004, JogS = 1005, JogSW = 1006, JogW = 1007, JogNW = 1008, JogUp = 1009, JogDown = 1010,
+                JogStepIncrease = 1020, JogStepDecrease = 1021,
+                JogSpeedIncrease = 1030, JogSpeedDecrease = 1031,
+                OverridePowerDefault = 1100, OverridePowerUp = 1101, OverridePowerDown = 1102,
+                OverrideLinearDefault = 1110, OverrideLinearUp = 1111, OverrideLinearDown = 1112,
+                OverrideRapidDefault = 1120, OverrideRapidUp = 1121, OverrideRapidDown = 1122,
+            }
+
+            private Keys mCombination = Keys.None;
+            private Actions mAction = Actions.None;
+            private string mHotKeyName;
+
+            // Does the hotkey's keyboard Combination match the incoming keys?
+            public bool IsMatch(Keys k1)
+            {
+                bool rv = k1 == Combination;
+                //System.Diagnostics.Debug.WriteLine(String.Format("{0} vs {1} = {2}", k1, k2, rv));
+                return rv;
+            }
+
+            // For built-in actions, the mAction is set
+            // For Custom Buttons, the hotkeyName is set
+            public string Action => string.IsNullOrEmpty(mHotKeyName) ? mAction.ToString() : mHotKeyName;
+
+            // Get access by a method to the action enum, not showing up in the datagrid
+            // For built-in action, the mAction enum is set
+            internal Actions GetActionEnum() => mAction;
+
+            // Get access by a method to the hotkeyName string, not showing up in the datagrid
+            // For Custom Buttons, the hotkeyName is set
+            internal string GetHotKeyName() => mHotKeyName;
+
+            // The chosen keyboard combination
+            public Keys Combination => mCombination;
+
+            // Ctor, typically for built-in actions
+            public HotKey(Actions action, Keys keys)
+            {
+                mAction = action;
+                mCombination = keys;
+            }
+
+            // Ctor, typically for custom button actions
+            public HotKey(string hotKeyName, Keys keys)
+            {
+                mHotKeyName = hotKeyName;
+                mCombination = keys;
+            }
+
+            public static bool ValidShortcut(Keys Combination)
+            {
+                Keys control = Keys.None;
+                Keys standard = Keys.None;
+
+                if (Combination != Keys.None)
+                {
+                    foreach (Keys x in Enum.GetValues(typeof(Keys)))
+                        if ((x & Combination) == x)
+                            if (IsStandard(x))
+                                standard |= x;
+                            else
+                                control |= x;
+                }
+
+                return standard != Keys.None;
+            }
+
+            private static bool IsStandard(Keys key) => IsLetter(key) || IsNumeric(key) || IsFunction(key);
+
+            private static bool IsNumeric(Keys key) => ((key >= Keys.D0 && key <= Keys.D9) || (key >= Keys.NumPad0 && key <= Keys.NumPad9));
+
+            private static bool IsLetter(Keys key) => (key >= Keys.A && key <= Keys.Z);
+
+            private static bool IsFunction(Keys key) => (key >= Keys.F1 && key <= Keys.F24);
+
+            private static bool IsModifier(Keys key) => (key & Keys.Modifiers) == key;
+
+            internal void SetShortcut(Keys shortcut)
+            { mCombination = shortcut; }
+
+            public object Clone() => this.MemberwiseClone();
+
+            // handy for debugging
+            public override string ToString() => Action.ToString() + ":" + mCombination.ToString();
 
         }
 
-		private void AddAllFeatures()
-		{
-			AddNew(new HotKey(HotKey.Actions.ConnectDisconnect, Keys.F12));
-			AddNew(new HotKey(HotKey.Actions.Connect, Keys.None));
-			AddNew(new HotKey(HotKey.Actions.Disconnect, Keys.None));
+        private void AddAllFeatures()
+        {
+            // add the built-in actions
+            AddNew(new HotKey(HotKey.Actions.ConnectDisconnect, Keys.F12));
+            AddNew(new HotKey(HotKey.Actions.Connect, Keys.None));
+            AddNew(new HotKey(HotKey.Actions.Disconnect, Keys.None));
 
-			AddNew(new HotKey(HotKey.Actions.OpenFile, Keys.Control | Keys.O));
-			AddNew(new HotKey(HotKey.Actions.ReopenLastFile, Keys.Control | Keys.R));
-			AddNew(new HotKey(HotKey.Actions.SaveFile, Keys.Control | Keys.S));
-			AddNew(new HotKey(HotKey.Actions.ExecuteFile, Keys.F5));
-			AddNew(new HotKey(HotKey.Actions.AbortFile, Keys.Control | Keys.F5));
+            AddNew(new HotKey(HotKey.Actions.OpenFile, Keys.Control | Keys.O));
+            AddNew(new HotKey(HotKey.Actions.ReopenLastFile, Keys.Control | Keys.R));
+            AddNew(new HotKey(HotKey.Actions.SaveFile, Keys.Control | Keys.S));
+            AddNew(new HotKey(HotKey.Actions.ExecuteFile, Keys.F5));
+            AddNew(new HotKey(HotKey.Actions.AbortFile, Keys.Control | Keys.F5));
 
-			AddNew(new HotKey(HotKey.Actions.HelpOnline, Keys.Control | Keys.F1));
+            AddNew(new HotKey(HotKey.Actions.HelpOnline, Keys.Control | Keys.F1));
 
-			AddNew(new HotKey(HotKey.Actions.Reset, Keys.Control | Keys.X));
-			AddNew(new HotKey(HotKey.Actions.Homing, Keys.Control | Keys.H));
-			AddNew(new HotKey(HotKey.Actions.Unlock, Keys.Control | Keys.U));
-			AddNew(new HotKey(HotKey.Actions.PauseJob, Keys.F6));
-			AddNew(new HotKey(HotKey.Actions.ResumeJob, Keys.F7));
-			AddNew(new HotKey(HotKey.Actions.SetNewZero, Keys.Control | Keys.Z));
+            AddNew(new HotKey(HotKey.Actions.Reset, Keys.Control | Keys.X));
+            AddNew(new HotKey(HotKey.Actions.Homing, Keys.Control | Keys.H));
+            AddNew(new HotKey(HotKey.Actions.Unlock, Keys.Control | Keys.U));
+            AddNew(new HotKey(HotKey.Actions.PauseJob, Keys.F6));
+            AddNew(new HotKey(HotKey.Actions.ResumeJob, Keys.F7));
+            AddNew(new HotKey(HotKey.Actions.SetNewZero, Keys.Control | Keys.Z));
 
-			AddNew(new HotKey(HotKey.Actions.JogHome, Keys.NumPad5));
-			AddNew(new HotKey(HotKey.Actions.JogN, Keys.NumPad8));
-			AddNew(new HotKey(HotKey.Actions.JogNE, Keys.NumPad9));
-			AddNew(new HotKey(HotKey.Actions.JogE, Keys.NumPad6));
-			AddNew(new HotKey(HotKey.Actions.JogSE, Keys.NumPad3));
-			AddNew(new HotKey(HotKey.Actions.JogS, Keys.NumPad2));
-			AddNew(new HotKey(HotKey.Actions.JogSW, Keys.NumPad1));
-			AddNew(new HotKey(HotKey.Actions.JogW, Keys.NumPad4));
+            AddNew(new HotKey(HotKey.Actions.JogHome, Keys.NumPad5));
+            AddNew(new HotKey(HotKey.Actions.JogN, Keys.NumPad8));
+            AddNew(new HotKey(HotKey.Actions.JogNE, Keys.NumPad9));
+            AddNew(new HotKey(HotKey.Actions.JogE, Keys.NumPad6));
+            AddNew(new HotKey(HotKey.Actions.JogSE, Keys.NumPad3));
+            AddNew(new HotKey(HotKey.Actions.JogS, Keys.NumPad2));
+            AddNew(new HotKey(HotKey.Actions.JogSW, Keys.NumPad1));
+            AddNew(new HotKey(HotKey.Actions.JogW, Keys.NumPad4));
             AddNew(new HotKey(HotKey.Actions.JogNW, Keys.NumPad7));
             AddNew(new HotKey(HotKey.Actions.JogUp, (Keys)107));
             AddNew(new HotKey(HotKey.Actions.JogDown, (Keys)109));
 
-			AddNew(new HotKey(HotKey.Actions.JogStepIncrease, Keys.Multiply));
-			AddNew(new HotKey(HotKey.Actions.JogStepDecrease, Keys.Divide));
+            AddNew(new HotKey(HotKey.Actions.JogStepIncrease, Keys.Multiply));
+            AddNew(new HotKey(HotKey.Actions.JogStepDecrease, Keys.Divide));
 
-			AddNew(new HotKey(HotKey.Actions.JogSpeedIncrease, Keys.None));
-			AddNew(new HotKey(HotKey.Actions.JogSpeedDecrease, Keys.None));
+            AddNew(new HotKey(HotKey.Actions.JogSpeedIncrease, Keys.None));
+            AddNew(new HotKey(HotKey.Actions.JogSpeedDecrease, Keys.None));
 
-			AddNew(new HotKey(HotKey.Actions.OverridePowerDefault, Keys.None));
+            AddNew(new HotKey(HotKey.Actions.OverridePowerDefault, Keys.None));
             AddNew(new HotKey(HotKey.Actions.OverridePowerUp, Keys.None));
-			AddNew(new HotKey(HotKey.Actions.OverridePowerDown, Keys.None));
+            AddNew(new HotKey(HotKey.Actions.OverridePowerDown, Keys.None));
 
-			AddNew(new HotKey(HotKey.Actions.OverrideLinearDefault, Keys.None));
-			AddNew(new HotKey(HotKey.Actions.OverrideLinearUp, Keys.None));
-			AddNew(new HotKey(HotKey.Actions.OverrideLinearDown, Keys.None));
+            AddNew(new HotKey(HotKey.Actions.OverrideLinearDefault, Keys.None));
+            AddNew(new HotKey(HotKey.Actions.OverrideLinearUp, Keys.None));
+            AddNew(new HotKey(HotKey.Actions.OverrideLinearDown, Keys.None));
 
-			AddNew(new HotKey(HotKey.Actions.OverrideRapidDefault, Keys.None));
-			AddNew(new HotKey(HotKey.Actions.OverrideRapidUp, Keys.None));
-			AddNew(new HotKey(HotKey.Actions.OverrideRapidDown, Keys.None));
+            AddNew(new HotKey(HotKey.Actions.OverrideRapidDefault, Keys.None));
+            AddNew(new HotKey(HotKey.Actions.OverrideRapidUp, Keys.None));
+            AddNew(new HotKey(HotKey.Actions.OverrideRapidDown, Keys.None));
 
-			AddNew(new HotKey(HotKey.Actions.CustomButton1, Keys.Control | Keys.D1));
-			AddNew(new HotKey(HotKey.Actions.CustomButton2, Keys.Control | Keys.D2));
-			AddNew(new HotKey(HotKey.Actions.CustomButton3, Keys.Control | Keys.D3));
-			AddNew(new HotKey(HotKey.Actions.CustomButton4, Keys.Control | Keys.D4));
-			AddNew(new HotKey(HotKey.Actions.CustomButton5, Keys.Control | Keys.D5));
-			AddNew(new HotKey(HotKey.Actions.CustomButton6, Keys.Control | Keys.D6));
-			AddNew(new HotKey(HotKey.Actions.CustomButton7, Keys.Control | Keys.D7));
-			AddNew(new HotKey(HotKey.Actions.CustomButton8, Keys.Control | Keys.D8));
-			AddNew(new HotKey(HotKey.Actions.CustomButton9, Keys.Control | Keys.D9));
-			AddNew(new HotKey(HotKey.Actions.CustomButton10, Keys.Control | Keys.D0));
-		}
+            AddNew(new HotKey(HotKey.Actions.Unlock, Keys.L));
 
-		private void AddNew(HotKey toadd)
-		{
-			foreach (HotKey hk in this)
-				if (hk.Action == toadd.Action)
-					return;
-			
-			Add(toadd);
-		}
+            // add the hotkeys for the custom buttons, initially assigned to None
+            foreach (CustomButton cb in CustomButtons.Buttons)
+                AddNew(new HotKey(cb.HotKeyName, Keys.None));
+        }
 
-		public void Init(GrblCore core, PreviewForm cbform, JogForm jogform)
-		{
-			mCore = core;
+        private void AddNew(HotKey toadd)
+        {
+            if (!(from hk in this where hk.Action == toadd.Action select hk).Any())
+                Add(toadd);
+        }
+
+        public void Init(GrblCore core, PreviewForm cbform, JogForm jogform)
+        {
+            mCore = core;
             mPreviewForm = cbform;
-			mJogForm = jogform;
+            mJogForm = jogform;
             mCustomButtonPressed = new List<int>();
             AddAllFeatures();
-			Sort(CompareKey);
-		}
+            Sort(CompareKey);
+        }
 
-		private int CompareKey(HotKey x, HotKey y)
-		{
-			return x.Action - y.Action;
-		}
+        private int CompareKey(HotKey x, HotKey y)
+        {
+            return string.Compare(y.Action, x.Action);
+        }
 
-		internal bool ManageHotKeys(Form parent, Keys keys)
-		{
+        internal bool ManageHotKeys(Form parent, Keys keys)
+        {
             if (keys == Keys.None)
             {
-				if (mJogKeyRequested)
-					mCore.EndJogV11();
-				mJogKeyRequested = false;
-
-				EmulateCustomButtonUp();
-                return false;
+                if (mJogKeyRequested)
+                    mCore.EndJogV11();
+                mJogKeyRequested = false;
+                EmulateCustomButtonUp();
             }
             else
-            { 
+            {
                 foreach (HotKey hk in this)
-                    if (Match(keys, hk.Combination))
-                        return PerformAction(parent, hk.Action);
-
-                return false;
+                    if (hk.IsMatch(keys))
+                        return PerformAction(parent, hk);
             }
-		}
 
-		private bool Match(Keys k1, Keys k2)
-		{
-			bool rv = k1 == k2;
-			//System.Diagnostics.Debug.WriteLine(String.Format("{0} vs {1} = {2}", k1, k2, rv));
-			return rv;	
-		}
+            return false;
+        }
 
-		private bool PerformAction(Form parent, HotKey.Actions action)
-		{
-			switch (action)
-			{
-				case HotKey.Actions.ConnectDisconnect:
-					mCore.HKConnectDisconnect(); break;
-				case HotKey.Actions.Connect:
-					mCore.HKConnect(); break;
-				case HotKey.Actions.Disconnect:
-					mCore.HKDisconnect(); break;
-				case HotKey.Actions.OpenFile:
-					mCore.OpenFile(Application.OpenForms[0]); break;
-				case HotKey.Actions.ReopenLastFile:
-					mCore.ReOpenFile(Application.OpenForms[0]); break;
-				case HotKey.Actions.SaveFile:
-					mCore.SaveProgram(parent, false, false, false, 1, false); break;
-				case HotKey.Actions.ExecuteFile:
-					mCore.RunProgram(parent); break;
-				case HotKey.Actions.AbortFile:
-					mCore.AbortProgram(); break;
-				case HotKey.Actions.HelpOnline:
-					mCore.HelpOnLine(); break;
-				case HotKey.Actions.Reset:
-					mCore.GrblReset(); break;
-				case HotKey.Actions.Homing:
-					mCore.GrblHoming(); break;
-				case HotKey.Actions.Unlock:
-					mCore.GrblUnlock(); break;
-				case HotKey.Actions.PauseJob:
-					mCore.FeedHold(false); break;
-				case HotKey.Actions.ResumeJob:
-					mCore.CycleStartResume(false); break;
-				case HotKey.Actions.SetNewZero:
-					mCore.SetNewZero(); break;
-				case HotKey.Actions.JogHome:
-					RequestJog(GrblCore.JogDirection.Home); break;
-				case HotKey.Actions.JogN:
-					RequestJog(GrblCore.JogDirection.N); break;
-				case HotKey.Actions.JogNE:
-					RequestJog(GrblCore.JogDirection.NE); break;
-				case HotKey.Actions.JogE:
-					RequestJog(GrblCore.JogDirection.E); break;
-				case HotKey.Actions.JogSE:
-					RequestJog(GrblCore.JogDirection.SE); break;
-				case HotKey.Actions.JogS:
-					RequestJog(GrblCore.JogDirection.S); break;
-				case HotKey.Actions.JogSW:
-					RequestJog(GrblCore.JogDirection.SW); break;
-				case HotKey.Actions.JogW:
-					RequestJog(GrblCore.JogDirection.W); break;
-				case HotKey.Actions.JogNW:
-					RequestJog(GrblCore.JogDirection.NW); break;
-				case HotKey.Actions.JogUp:
-					RequestJog(GrblCore.JogDirection.Zup); break;
-				case HotKey.Actions.JogDown:
-					RequestJog(GrblCore.JogDirection.Zdown); break;
-				case HotKey.Actions.JogStepIncrease:
-					ChangeJogStep(true); break;
-				case HotKey.Actions.JogStepDecrease:
-					ChangeJogStep(false); break;
-				case HotKey.Actions.JogSpeedIncrease:
-					ChangeJogSpeed(true); break;
-				case HotKey.Actions.JogSpeedDecrease:
-					ChangeJogSpeed(false); break;
-				case HotKey.Actions.OverridePowerDefault:
-				case HotKey.Actions.OverridePowerUp:
-				case HotKey.Actions.OverridePowerDown:
-				case HotKey.Actions.OverrideLinearDefault:
-				case HotKey.Actions.OverrideLinearUp:
-				case HotKey.Actions.OverrideLinearDown:
-				case HotKey.Actions.OverrideRapidDefault:
-				case HotKey.Actions.OverrideRapidUp:
-				case HotKey.Actions.OverrideRapidDown:
-					mCore.HotKeyOverride(action); break;
-				case HotKey.Actions.CustomButton1:
-					EmulateCustomButtonDown(0); break;
-				case HotKey.Actions.CustomButton2:
-					EmulateCustomButtonDown(1); break;
-				case HotKey.Actions.CustomButton3:
-					EmulateCustomButtonDown(2); break;
-				case HotKey.Actions.CustomButton4:
-					EmulateCustomButtonDown(3); break;
-				case HotKey.Actions.CustomButton5:
-					EmulateCustomButtonDown(4); break;
-				case HotKey.Actions.CustomButton6:
-					EmulateCustomButtonDown(5); break;
-				case HotKey.Actions.CustomButton7:
-					EmulateCustomButtonDown(6); break;
-				case HotKey.Actions.CustomButton8:
-					EmulateCustomButtonDown(7); break;
-				case HotKey.Actions.CustomButton9:
-					EmulateCustomButtonDown(8); break;
-				case HotKey.Actions.CustomButton10:
-					EmulateCustomButtonDown(9); break;
-				default:
-					break;
-			}
+        private bool PerformAction(Form parent, HotKey hotKey)
+        {
+            // let's see if it's a regular built-in action
+            var action = hotKey.GetActionEnum();
+            switch (action)
+            {
+                case HotKey.Actions.ConnectDisconnect:
+                    mCore.HKConnectDisconnect(); break;
+                case HotKey.Actions.Connect:
+                    mCore.HKConnect(); break;
+                case HotKey.Actions.Disconnect:
+                    mCore.HKDisconnect(); break;
+                case HotKey.Actions.OpenFile:
+                    mCore.OpenFile(Application.OpenForms[0]); break;
+                case HotKey.Actions.ReopenLastFile:
+                    mCore.ReOpenFile(Application.OpenForms[0]); break;
+                case HotKey.Actions.SaveFile:
+                    mCore.SaveProgram(parent, false, false, false, 1, false); break;
+                case HotKey.Actions.ExecuteFile:
+                    mCore.RunProgram(parent); break;
+                case HotKey.Actions.AbortFile:
+                    mCore.AbortProgram(); break;
+                case HotKey.Actions.HelpOnline:
+                    mCore.HelpOnLine(); break;
+                case HotKey.Actions.Reset:
+                    mCore.GrblReset(); break;
+                case HotKey.Actions.Homing:
+                    mCore.GrblHoming(); break;
+                case HotKey.Actions.Unlock:
+                    mCore.GrblUnlock(); break;
+                case HotKey.Actions.PauseJob:
+                    mCore.FeedHold(false); break;
+                case HotKey.Actions.ResumeJob:
+                    mCore.CycleStartResume(false); break;
+                case HotKey.Actions.SetNewZero:
+                    mCore.SetNewZero(); break;
+                case HotKey.Actions.JogHome:
+                    RequestJog(GrblCore.JogDirection.Home); break;
+                case HotKey.Actions.JogN:
+                    RequestJog(GrblCore.JogDirection.N); break;
+                case HotKey.Actions.JogNE:
+                    RequestJog(GrblCore.JogDirection.NE); break;
+                case HotKey.Actions.JogE:
+                    RequestJog(GrblCore.JogDirection.E); break;
+                case HotKey.Actions.JogSE:
+                    RequestJog(GrblCore.JogDirection.SE); break;
+                case HotKey.Actions.JogS:
+                    RequestJog(GrblCore.JogDirection.S); break;
+                case HotKey.Actions.JogSW:
+                    RequestJog(GrblCore.JogDirection.SW); break;
+                case HotKey.Actions.JogW:
+                    RequestJog(GrblCore.JogDirection.W); break;
+                case HotKey.Actions.JogNW:
+                    RequestJog(GrblCore.JogDirection.NW); break;
+                case HotKey.Actions.JogUp:
+                    RequestJog(GrblCore.JogDirection.Zup); break;
+                case HotKey.Actions.JogDown:
+                    RequestJog(GrblCore.JogDirection.Zdown); break;
+                case HotKey.Actions.JogStepIncrease:
+                    ChangeJogStep(true); break;
+                case HotKey.Actions.JogStepDecrease:
+                    ChangeJogStep(false); break;
+                case HotKey.Actions.JogSpeedIncrease:
+                    ChangeJogSpeed(true); break;
+                case HotKey.Actions.JogSpeedDecrease:
+                    ChangeJogSpeed(false); break;
+                case HotKey.Actions.OverridePowerDefault:
+                case HotKey.Actions.OverridePowerUp:
+                case HotKey.Actions.OverridePowerDown:
+                case HotKey.Actions.OverrideLinearDefault:
+                case HotKey.Actions.OverrideLinearUp:
+                case HotKey.Actions.OverrideLinearDown:
+                case HotKey.Actions.OverrideRapidDefault:
+                case HotKey.Actions.OverrideRapidUp:
+                case HotKey.Actions.OverrideRapidDown:
+                    mCore.HotKeyOverride(action);
+                    break;
+                default:
+                    // let's handle CustomButtons here
+                    if (!string.IsNullOrEmpty(hotKey.GetHotKeyName()))
+                    {
+                        var buttons = mPreviewForm.CustomImageButtons;
+                        var len = buttons.Count;
+                        for (int t = 0; t < len; ++t)
+                        {
+                            var customButton = buttons[t].CustomButton;
+                            if (customButton.HotKeyName == hotKey.GetHotKeyName() && customButton.EnabledNow(mCore))
+                            {
+                                EmulateCustomButtonDown(t);
+                                return true;
+                            }
+                        }
+                    }
+                    break;
+            }
 
-			//ConnectDisconnect = 10, Connect = 11, Disconnect = 12,
-			//OpenFile = 20, ReopenLastFile = 21, SaveFile = 22, ExecuteFile = 23,
-			//HelpOnline = 30,
-			//Reset = 100, Homing = 101, Unlock = 102,  PauseJob = 103, ResumeJob = 104, SetNewZero = 105,
-			//JogHome = 1000, JogN = 1001, JogNE = 1002, JogE = 1003, JogSE = 1004, JogS = 1005, JogSO = 1006, JogO = 1007, JogNO = 1008,
-			//CustomButton1 = 2000, CustomButton2 = 2001, CustomButton3 = 2002, CustomButton4 = 2003, CustomButton5 = 2004, CustomButton6 = 2005, CustomButton7 = 2006, CustomButton8 = 2007, CustomButton9 = 2008, CustomButton10 = 2009
+            return false;
+        }
 
-			return true;
-		}
+        private void ChangeJogStep(bool increase)
+        {
+            if (mCore.JogEnabled)
+                mJogForm.ChangeJogStepIndexBy(increase ? 1 : -1);
+        }
 
-		private void ChangeJogStep(bool increase)
-		{
-			if (mCore.JogEnabled)
-				mJogForm.ChangeJogStepIndexBy(increase ? 1 : -1);
-		}
+        private void ChangeJogSpeed(bool increase)
+        {
+            if (mCore.JogEnabled)
+                mJogForm.ChangeJogSpeedIndexBy(increase ? 1 : -1);
+        }
 
-		private void ChangeJogSpeed(bool increase)
-		{
-			if (mCore.JogEnabled)
-				mJogForm.ChangeJogSpeedIndexBy(increase ? 1 : -1);
-		}
-
-		private void RequestJog(GrblCore.JogDirection dir)
-		{
-			mJogKeyRequested = true;
-			mCore.BeginJog(dir, false);
-		}
+        private void RequestJog(GrblCore.JogDirection dir)
+        {
+            mJogKeyRequested = true;
+            mCore.BeginJog(dir, false);
+        }
         private void EmulateCustomButtonDown(int index)
         {
             List<PreviewForm.CustomButtonIB> buttons = mPreviewForm.CustomImageButtons;
             if (index < buttons.Count)
             {
                 if (!mCustomButtonPressed.Contains(index))
-                { 
+                {
                     mCustomButtonPressed.Add(index);
                     buttons[index].EmulateMouseInside = true;
                     buttons[index].PerformMouseDown(new MouseEventArgs(MouseButtons.Left, 1, 1, 1, 0));
@@ -360,7 +350,6 @@ namespace LaserGRBL
         private void EmulateCustomButtonUp()
         {
             List<PreviewForm.CustomButtonIB> buttons = mPreviewForm.CustomImageButtons;
-
             foreach (int index in mCustomButtonPressed)
             {
                 if (index < buttons.Count)
@@ -376,11 +365,11 @@ namespace LaserGRBL
 
 
         public List<HotKeysManager.HotKey> GetEditList()
-		{
-			List<HotKeysManager.HotKey> rv = new List<HotKeysManager.HotKey>();
-			foreach (HotKeysManager.HotKey hk in this)
-				rv.Add(hk.Clone() as HotKeysManager.HotKey);
-			return rv;
-		}
-	}
+        {
+            List<HotKeysManager.HotKey> rv = new List<HotKeysManager.HotKey>();
+            foreach (HotKeysManager.HotKey hk in this)
+                rv.Add(hk.Clone() as HotKeysManager.HotKey);
+            return rv;
+        }
+    }
 }

--- a/LaserGRBL/HotkeyManagerForm.Designer.cs
+++ b/LaserGRBL/HotkeyManagerForm.Designer.cs
@@ -28,107 +28,108 @@
 		/// </summary>
 		private void InitializeComponent()
 		{
-			System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(HotkeyManagerForm));
-			this.tableLayoutPanel1 = new System.Windows.Forms.TableLayoutPanel();
-			this.tableLayoutPanel2 = new System.Windows.Forms.TableLayoutPanel();
-			this.LblConnect = new System.Windows.Forms.Label();
-			this.BtnCancel = new System.Windows.Forms.Button();
-			this.BtnSave = new System.Windows.Forms.Button();
-			this.GB = new System.Windows.Forms.GroupBox();
-			this.DGV = new LaserGRBL.MyDatagridView();
-			this.Action = new System.Windows.Forms.DataGridViewTextBoxColumn();
-			this.Shortcut = new System.Windows.Forms.DataGridViewTextBoxColumn();
-			this.tableLayoutPanel1.SuspendLayout();
-			this.tableLayoutPanel2.SuspendLayout();
-			this.GB.SuspendLayout();
-			((System.ComponentModel.ISupportInitialize)(this.DGV)).BeginInit();
-			this.SuspendLayout();
-			// 
-			// tableLayoutPanel1
-			// 
-			resources.ApplyResources(this.tableLayoutPanel1, "tableLayoutPanel1");
-			this.tableLayoutPanel1.Controls.Add(this.tableLayoutPanel2, 0, 1);
-			this.tableLayoutPanel1.Controls.Add(this.GB, 0, 0);
-			this.tableLayoutPanel1.Name = "tableLayoutPanel1";
-			// 
-			// tableLayoutPanel2
-			// 
-			resources.ApplyResources(this.tableLayoutPanel2, "tableLayoutPanel2");
-			this.tableLayoutPanel2.Controls.Add(this.LblConnect, 0, 0);
-			this.tableLayoutPanel2.Controls.Add(this.BtnCancel, 1, 0);
-			this.tableLayoutPanel2.Controls.Add(this.BtnSave, 2, 0);
-			this.tableLayoutPanel2.Name = "tableLayoutPanel2";
-			// 
-			// LblConnect
-			// 
-			resources.ApplyResources(this.LblConnect, "LblConnect");
-			this.LblConnect.ForeColor = System.Drawing.Color.Red;
-			this.LblConnect.Name = "LblConnect";
-			// 
-			// BtnCancel
-			// 
-			this.BtnCancel.DialogResult = System.Windows.Forms.DialogResult.Cancel;
-			resources.ApplyResources(this.BtnCancel, "BtnCancel");
-			this.BtnCancel.Name = "BtnCancel";
-			this.BtnCancel.UseVisualStyleBackColor = true;
-			// 
-			// BtnSave
-			// 
-			this.BtnSave.DialogResult = System.Windows.Forms.DialogResult.OK;
-			resources.ApplyResources(this.BtnSave, "BtnSave");
-			this.BtnSave.Name = "BtnSave";
-			this.BtnSave.UseVisualStyleBackColor = true;
-			this.BtnSave.Click += new System.EventHandler(this.BtnSave_Click);
-			// 
-			// GB
-			// 
-			this.GB.Controls.Add(this.DGV);
-			resources.ApplyResources(this.GB, "GB");
-			this.GB.Name = "GB";
-			this.GB.TabStop = false;
-			// 
-			// DGV
-			// 
-			this.DGV.AllowUserToAddRows = false;
-			this.DGV.AllowUserToDeleteRows = false;
-			this.DGV.AllowUserToResizeRows = false;
-			this.DGV.ColumnHeadersHeightSizeMode = System.Windows.Forms.DataGridViewColumnHeadersHeightSizeMode.AutoSize;
-			this.DGV.Columns.AddRange(new System.Windows.Forms.DataGridViewColumn[] {
+            System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(HotkeyManagerForm));
+            this.tableLayoutPanel1 = new System.Windows.Forms.TableLayoutPanel();
+            this.tableLayoutPanel2 = new System.Windows.Forms.TableLayoutPanel();
+            this.LblConnect = new System.Windows.Forms.Label();
+            this.BtnCancel = new System.Windows.Forms.Button();
+            this.BtnSave = new System.Windows.Forms.Button();
+            this.GB = new System.Windows.Forms.GroupBox();
+            this.DGVF = new LaserGRBL.MyDatagridView();
+            this.Action = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.Shortcut = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.tableLayoutPanel1.SuspendLayout();
+            this.tableLayoutPanel2.SuspendLayout();
+            this.GB.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.DGVF)).BeginInit();
+            this.SuspendLayout();
+            // 
+            // tableLayoutPanel1
+            // 
+            resources.ApplyResources(this.tableLayoutPanel1, "tableLayoutPanel1");
+            this.tableLayoutPanel1.Controls.Add(this.tableLayoutPanel2, 0, 1);
+            this.tableLayoutPanel1.Controls.Add(this.GB, 0, 0);
+            this.tableLayoutPanel1.Name = "tableLayoutPanel1";
+            // 
+            // tableLayoutPanel2
+            // 
+            resources.ApplyResources(this.tableLayoutPanel2, "tableLayoutPanel2");
+            this.tableLayoutPanel2.Controls.Add(this.LblConnect, 0, 0);
+            this.tableLayoutPanel2.Controls.Add(this.BtnCancel, 1, 0);
+            this.tableLayoutPanel2.Controls.Add(this.BtnSave, 2, 0);
+            this.tableLayoutPanel2.Name = "tableLayoutPanel2";
+            // 
+            // LblConnect
+            // 
+            resources.ApplyResources(this.LblConnect, "LblConnect");
+            this.LblConnect.ForeColor = System.Drawing.Color.Red;
+            this.LblConnect.Name = "LblConnect";
+            // 
+            // BtnCancel
+            // 
+            this.BtnCancel.DialogResult = System.Windows.Forms.DialogResult.Cancel;
+            resources.ApplyResources(this.BtnCancel, "BtnCancel");
+            this.BtnCancel.Name = "BtnCancel";
+            this.BtnCancel.UseVisualStyleBackColor = true;
+            // 
+            // BtnSave
+            // 
+            this.BtnSave.DialogResult = System.Windows.Forms.DialogResult.OK;
+            resources.ApplyResources(this.BtnSave, "BtnSave");
+            this.BtnSave.Name = "BtnSave";
+            this.BtnSave.UseVisualStyleBackColor = true;
+            this.BtnSave.Click += new System.EventHandler(this.BtnSave_Click);
+            // 
+            // GB
+            // 
+            this.GB.Controls.Add(this.DGVF);
+            resources.ApplyResources(this.GB, "GB");
+            this.GB.Name = "GB";
+            this.GB.TabStop = false;
+            // 
+            // DGVF
+            // 
+            this.DGVF.AllowUserToAddRows = false;
+            this.DGVF.AllowUserToDeleteRows = false;
+            this.DGVF.AllowUserToResizeRows = false;
+            this.DGVF.ColumnHeadersHeightSizeMode = System.Windows.Forms.DataGridViewColumnHeadersHeightSizeMode.AutoSize;
+            this.DGVF.Columns.AddRange(new System.Windows.Forms.DataGridViewColumn[] {
             this.Action,
             this.Shortcut});
-			resources.ApplyResources(this.DGV, "DGV");
-			this.DGV.Name = "DGV";
-			this.DGV.SelectionMode = System.Windows.Forms.DataGridViewSelectionMode.FullRowSelect;
-			// 
-			// Action
-			// 
-			this.Action.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.AllCells;
-			this.Action.DataPropertyName = "Action";
-			resources.ApplyResources(this.Action, "Action");
-			this.Action.Name = "Action";
-			this.Action.ReadOnly = true;
-			// 
-			// Shortcut
-			// 
-			this.Shortcut.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.Fill;
-			this.Shortcut.DataPropertyName = "Combination";
-			resources.ApplyResources(this.Shortcut, "Shortcut");
-			this.Shortcut.Name = "Shortcut";
-			this.Shortcut.ReadOnly = true;
-			// 
-			// HotkeyManagerForm
-			// 
-			resources.ApplyResources(this, "$this");
-			this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-			this.Controls.Add(this.tableLayoutPanel1);
-			this.KeyPreview = true;
-			this.Name = "HotkeyManagerForm";
-			this.tableLayoutPanel1.ResumeLayout(false);
-			this.tableLayoutPanel2.ResumeLayout(false);
-			this.tableLayoutPanel2.PerformLayout();
-			this.GB.ResumeLayout(false);
-			((System.ComponentModel.ISupportInitialize)(this.DGV)).EndInit();
-			this.ResumeLayout(false);
+            resources.ApplyResources(this.DGVF, "DGVF");
+            this.DGVF.Name = "DGVF";
+            this.DGVF.SelectionMode = System.Windows.Forms.DataGridViewSelectionMode.FullRowSelect;
+            this.DGVF.DataError += new System.Windows.Forms.DataGridViewDataErrorEventHandler(this.DGV_DataError);
+            // 
+            // Action
+            // 
+            this.Action.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.AllCells;
+            this.Action.DataPropertyName = "Action";
+            resources.ApplyResources(this.Action, "Action");
+            this.Action.Name = "Action";
+            this.Action.ReadOnly = true;
+            // 
+            // Shortcut
+            // 
+            this.Shortcut.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.Fill;
+            this.Shortcut.DataPropertyName = "Combination";
+            resources.ApplyResources(this.Shortcut, "Shortcut");
+            this.Shortcut.Name = "Shortcut";
+            this.Shortcut.ReadOnly = true;
+            // 
+            // HotkeyManagerForm
+            // 
+            resources.ApplyResources(this, "$this");
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.Controls.Add(this.tableLayoutPanel1);
+            this.KeyPreview = true;
+            this.Name = "HotkeyManagerForm";
+            this.tableLayoutPanel1.ResumeLayout(false);
+            this.tableLayoutPanel2.ResumeLayout(false);
+            this.tableLayoutPanel2.PerformLayout();
+            this.GB.ResumeLayout(false);
+            ((System.ComponentModel.ISupportInitialize)(this.DGVF)).EndInit();
+            this.ResumeLayout(false);
 
 		}
 
@@ -138,7 +139,7 @@
 		private System.Windows.Forms.TableLayoutPanel tableLayoutPanel2;
 		private System.Windows.Forms.GroupBox GB;
 		private System.Windows.Forms.Button BtnCancel;
-		private MyDatagridView DGV;
+		private MyDatagridView DGVF;
 		private System.Windows.Forms.Button BtnSave;
 		private System.Windows.Forms.Label LblConnect;
 		private System.Windows.Forms.DataGridViewTextBoxColumn Action;

--- a/LaserGRBL/HotkeyManagerForm.Designer.cs
+++ b/LaserGRBL/HotkeyManagerForm.Designer.cs
@@ -35,13 +35,13 @@
             this.BtnCancel = new System.Windows.Forms.Button();
             this.BtnSave = new System.Windows.Forms.Button();
             this.GB = new System.Windows.Forms.GroupBox();
-            this.DGVF = new LaserGRBL.MyDatagridView();
+            this.DGV = new LaserGRBL.MyDatagridView();
             this.Action = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.Shortcut = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.tableLayoutPanel1.SuspendLayout();
             this.tableLayoutPanel2.SuspendLayout();
             this.GB.SuspendLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.DGVF)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.DGV)).BeginInit();
             this.SuspendLayout();
             // 
             // tableLayoutPanel1
@@ -82,24 +82,24 @@
             // 
             // GB
             // 
-            this.GB.Controls.Add(this.DGVF);
+            this.GB.Controls.Add(this.DGV);
             resources.ApplyResources(this.GB, "GB");
             this.GB.Name = "GB";
             this.GB.TabStop = false;
             // 
-            // DGVF
+            // DGV
             // 
-            this.DGVF.AllowUserToAddRows = false;
-            this.DGVF.AllowUserToDeleteRows = false;
-            this.DGVF.AllowUserToResizeRows = false;
-            this.DGVF.ColumnHeadersHeightSizeMode = System.Windows.Forms.DataGridViewColumnHeadersHeightSizeMode.AutoSize;
-            this.DGVF.Columns.AddRange(new System.Windows.Forms.DataGridViewColumn[] {
+            this.DGV.AllowUserToAddRows = false;
+            this.DGV.AllowUserToDeleteRows = false;
+            this.DGV.AllowUserToResizeRows = false;
+            this.DGV.ColumnHeadersHeightSizeMode = System.Windows.Forms.DataGridViewColumnHeadersHeightSizeMode.AutoSize;
+            this.DGV.Columns.AddRange(new System.Windows.Forms.DataGridViewColumn[] {
             this.Action,
             this.Shortcut});
-            resources.ApplyResources(this.DGVF, "DGVF");
-            this.DGVF.Name = "DGVF";
-            this.DGVF.SelectionMode = System.Windows.Forms.DataGridViewSelectionMode.FullRowSelect;
-            this.DGVF.DataError += new System.Windows.Forms.DataGridViewDataErrorEventHandler(this.DGV_DataError);
+            resources.ApplyResources(this.DGV, "DGV");
+            this.DGV.Name = "DGV";
+            this.DGV.SelectionMode = System.Windows.Forms.DataGridViewSelectionMode.FullRowSelect;
+            this.DGV.DataError += new System.Windows.Forms.DataGridViewDataErrorEventHandler(this.DGV_DataError);
             // 
             // Action
             // 
@@ -128,7 +128,7 @@
             this.tableLayoutPanel2.ResumeLayout(false);
             this.tableLayoutPanel2.PerformLayout();
             this.GB.ResumeLayout(false);
-            ((System.ComponentModel.ISupportInitialize)(this.DGVF)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.DGV)).EndInit();
             this.ResumeLayout(false);
 
 		}
@@ -139,7 +139,7 @@
 		private System.Windows.Forms.TableLayoutPanel tableLayoutPanel2;
 		private System.Windows.Forms.GroupBox GB;
 		private System.Windows.Forms.Button BtnCancel;
-		private MyDatagridView DGVF;
+		private MyDatagridView DGV;
 		private System.Windows.Forms.Button BtnSave;
 		private System.Windows.Forms.Label LblConnect;
 		private System.Windows.Forms.DataGridViewTextBoxColumn Action;

--- a/LaserGRBL/HotkeyManagerForm.cs
+++ b/LaserGRBL/HotkeyManagerForm.cs
@@ -6,11 +6,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.ComponentModel;
-using System.Data;
-using System.Drawing;
-using System.Linq;
-using System.Text;
 using System.Windows.Forms;
 
 namespace LaserGRBL
@@ -19,6 +14,7 @@ namespace LaserGRBL
 	{
 		private List<HotKeysManager.HotKey> mLocalList = null;
 		GrblCore mCore = null;
+
 		public HotkeyManagerForm(GrblCore core)
 		{
 			InitializeComponent();
@@ -27,19 +23,19 @@ namespace LaserGRBL
 			BackColor = ColorScheme.FormBackColor;
 			GB.ForeColor = ForeColor = ColorScheme.FormForeColor;
             GB.BackColor = ColorScheme.FormBackColor;
-            DGV.EnableHeadersVisualStyles = false;
-            DGV.BackgroundColor = ColorScheme.FormBackColor; //SystemColors.Control;
-			DGV.ForeColor = ColorScheme.FormForeColor; //SystemColors.ControlText;
-            DGV.DefaultCellStyle.BackColor = ColorScheme.FormBackColor;
-            DGV.ColumnHeadersDefaultCellStyle.BackColor = ColorScheme.FormBackColor;
-            DGV.ColumnHeadersDefaultCellStyle.ForeColor = ColorScheme.FormForeColor;
-            DGV.RowHeadersDefaultCellStyle.BackColor = ColorScheme.FormBackColor;
-            DGV.RowHeadersDefaultCellStyle.ForeColor = ColorScheme.FormForeColor;
+            DGVF.EnableHeadersVisualStyles = false;
+            DGVF.BackgroundColor = ColorScheme.FormBackColor; //SystemColors.Control;
+			DGVF.ForeColor = ColorScheme.FormForeColor; //SystemColors.ControlText;
+            DGVF.DefaultCellStyle.BackColor = ColorScheme.FormBackColor;
+            DGVF.ColumnHeadersDefaultCellStyle.BackColor = ColorScheme.FormBackColor;
+            DGVF.ColumnHeadersDefaultCellStyle.ForeColor = ColorScheme.FormForeColor;
+            DGVF.RowHeadersDefaultCellStyle.BackColor = ColorScheme.FormBackColor;
+            DGVF.RowHeadersDefaultCellStyle.ForeColor = ColorScheme.FormForeColor;
             BtnSave.BackColor = BtnCancel.BackColor = ColorScheme.FormButtonsColor;
 
-
 			mLocalList = core.HotKeys.GetEditList();
-			DGV.DataSource = mLocalList;
+			DGVF.DataSource = mLocalList;
+
             ComputeErrors();
 		}
 
@@ -61,7 +57,7 @@ namespace LaserGRBL
 			if (keyData != mLastkeyData)
 			{
 				mLastkeyData = keyData;
-				HotKeysManager.HotKey hk = DGV.CurrentRow.DataBoundItem as HotKeysManager.HotKey;
+				HotKeysManager.HotKey hk = DGVF.CurrentRow.DataBoundItem as HotKeysManager.HotKey;
 
 				if (HotKeysManager.HotKey.ValidShortcut(mLastkeyData))
 					SetNewValue(hk, mLastkeyData);
@@ -78,7 +74,7 @@ namespace LaserGRBL
 		private void SetNewValue(HotKeysManager.HotKey hk, Keys value)
 		{
 			hk.SetShortcut(value);
-			DGV.Refresh();
+			DGVF.Refresh();
 			ComputeErrors();
 		}
 
@@ -86,11 +82,11 @@ namespace LaserGRBL
 		{
 			List<DataGridViewRow> inerror = new List<DataGridViewRow>();
 			List<DataGridViewRow> noerror = new List<DataGridViewRow>();
-			foreach (DataGridViewRow ra in DGV.Rows)
+			foreach (DataGridViewRow ra in DGVF.Rows)
 			{
 				HotKeysManager.HotKey a = ra.DataBoundItem as HotKeysManager.HotKey;
 
-				foreach (DataGridViewRow rb in DGV.Rows)
+				foreach (DataGridViewRow rb in DGVF.Rows)
 				{
 					HotKeysManager.HotKey b = rb.DataBoundItem as HotKeysManager.HotKey;
 					if (!ReferenceEquals(a, b) && a.Combination != Keys.None && a.Combination == b.Combination)
@@ -113,5 +109,11 @@ namespace LaserGRBL
 		{
 			mCore.WriteHotkeys(mLocalList);
 		}
-	}
+
+        private void DGV_DataError(object sender, DataGridViewDataErrorEventArgs e)
+        {
+			// added this for debugging.. it's rather optional, but here just in case you want to put a breakpoint and examine
+			Console.WriteLine("datagrid exception:", e.ToString());
+        }
+    }
 }

--- a/LaserGRBL/HotkeyManagerForm.cs
+++ b/LaserGRBL/HotkeyManagerForm.cs
@@ -23,18 +23,18 @@ namespace LaserGRBL
 			BackColor = ColorScheme.FormBackColor;
 			GB.ForeColor = ForeColor = ColorScheme.FormForeColor;
             GB.BackColor = ColorScheme.FormBackColor;
-            DGVF.EnableHeadersVisualStyles = false;
-            DGVF.BackgroundColor = ColorScheme.FormBackColor; //SystemColors.Control;
-			DGVF.ForeColor = ColorScheme.FormForeColor; //SystemColors.ControlText;
-            DGVF.DefaultCellStyle.BackColor = ColorScheme.FormBackColor;
-            DGVF.ColumnHeadersDefaultCellStyle.BackColor = ColorScheme.FormBackColor;
-            DGVF.ColumnHeadersDefaultCellStyle.ForeColor = ColorScheme.FormForeColor;
-            DGVF.RowHeadersDefaultCellStyle.BackColor = ColorScheme.FormBackColor;
-            DGVF.RowHeadersDefaultCellStyle.ForeColor = ColorScheme.FormForeColor;
+            DGV.EnableHeadersVisualStyles = false;
+            DGV.BackgroundColor = ColorScheme.FormBackColor; //SystemColors.Control;
+			DGV.ForeColor = ColorScheme.FormForeColor; //SystemColors.ControlText;
+            DGV.DefaultCellStyle.BackColor = ColorScheme.FormBackColor;
+            DGV.ColumnHeadersDefaultCellStyle.BackColor = ColorScheme.FormBackColor;
+            DGV.ColumnHeadersDefaultCellStyle.ForeColor = ColorScheme.FormForeColor;
+            DGV.RowHeadersDefaultCellStyle.BackColor = ColorScheme.FormBackColor;
+            DGV.RowHeadersDefaultCellStyle.ForeColor = ColorScheme.FormForeColor;
             BtnSave.BackColor = BtnCancel.BackColor = ColorScheme.FormButtonsColor;
 
 			mLocalList = core.HotKeys.GetEditList();
-			DGVF.DataSource = mLocalList;
+			DGV.DataSource = mLocalList;
 
             ComputeErrors();
 		}
@@ -57,7 +57,7 @@ namespace LaserGRBL
 			if (keyData != mLastkeyData)
 			{
 				mLastkeyData = keyData;
-				HotKeysManager.HotKey hk = DGVF.CurrentRow.DataBoundItem as HotKeysManager.HotKey;
+				HotKeysManager.HotKey hk = DGV.CurrentRow.DataBoundItem as HotKeysManager.HotKey;
 
 				if (HotKeysManager.HotKey.ValidShortcut(mLastkeyData))
 					SetNewValue(hk, mLastkeyData);
@@ -74,7 +74,7 @@ namespace LaserGRBL
 		private void SetNewValue(HotKeysManager.HotKey hk, Keys value)
 		{
 			hk.SetShortcut(value);
-			DGVF.Refresh();
+			DGV.Refresh();
 			ComputeErrors();
 		}
 
@@ -82,11 +82,11 @@ namespace LaserGRBL
 		{
 			List<DataGridViewRow> inerror = new List<DataGridViewRow>();
 			List<DataGridViewRow> noerror = new List<DataGridViewRow>();
-			foreach (DataGridViewRow ra in DGVF.Rows)
+			foreach (DataGridViewRow ra in DGV.Rows)
 			{
 				HotKeysManager.HotKey a = ra.DataBoundItem as HotKeysManager.HotKey;
 
-				foreach (DataGridViewRow rb in DGVF.Rows)
+				foreach (DataGridViewRow rb in DGV.Rows)
 				{
 					HotKeysManager.HotKey b = rb.DataBoundItem as HotKeysManager.HotKey;
 					if (!ReferenceEquals(a, b) && a.Combination != Keys.None && a.Combination == b.Combination)

--- a/LaserGRBL/HotkeyManagerForm.resx
+++ b/LaserGRBL/HotkeyManagerForm.resx
@@ -112,19 +112,19 @@
     <value>2.0</value>
   </resheader>
   <resheader name="reader">
-    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <resheader name="writer">
-    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <assembly alias="mscorlib" name="mscorlib, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <assembly alias="mscorlib" name="mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="tableLayoutPanel1.ColumnCount" type="System.Int32, mscorlib">
     <value>1</value>
   </data>
   <data name="tableLayoutPanel2.ColumnCount" type="System.Int32, mscorlib">
     <value>3</value>
   </data>
-  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="LblConnect.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>None</value>
   </data>
@@ -134,7 +134,7 @@
   <data name="LblConnect.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
   </data>
-  <assembly alias="System.Drawing" name="System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   <data name="LblConnect.Location" type="System.Drawing.Point, System.Drawing">
     <value>48, 11</value>
   </data>
@@ -155,7 +155,7 @@ Press "Canc" keyboard key to remove shortcut.</value>
     <value>LblConnect</value>
   </data>
   <data name="&gt;&gt;LblConnect.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;LblConnect.Parent" xml:space="preserve">
     <value>tableLayoutPanel2</value>
@@ -229,7 +229,7 @@ Press "Canc" keyboard key to remove shortcut.</value>
     <value>BtnCancel</value>
   </data>
   <data name="&gt;&gt;BtnCancel.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;BtnCancel.Parent" xml:space="preserve">
     <value>tableLayoutPanel2</value>
@@ -295,7 +295,7 @@ Press "Canc" keyboard key to remove shortcut.</value>
     <value>BtnSave</value>
   </data>
   <data name="&gt;&gt;BtnSave.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;BtnSave.Parent" xml:space="preserve">
     <value>tableLayoutPanel2</value>
@@ -322,7 +322,7 @@ Press "Canc" keyboard key to remove shortcut.</value>
     <value>tableLayoutPanel2</value>
   </data>
   <data name="&gt;&gt;tableLayoutPanel2.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TableLayoutPanel, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.TableLayoutPanel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;tableLayoutPanel2.Parent" xml:space="preserve">
     <value>tableLayoutPanel1</value>
@@ -333,7 +333,7 @@ Press "Canc" keyboard key to remove shortcut.</value>
   <data name="tableLayoutPanel2.LayoutSettings" type="System.Windows.Forms.TableLayoutSettings, System.Windows.Forms">
     <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="LblConnect" Row="0" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="BtnCancel" Row="0" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="BtnSave" Row="0" RowSpan="1" Column="2" ColumnSpan="1" /&gt;&lt;/Controls&gt;&lt;Columns Styles="Percent,100,AutoSize,0,AutoSize,0" /&gt;&lt;Rows Styles="AutoSize,0" /&gt;&lt;/TableLayoutSettings&gt;</value>
   </data>
-  <metadata name="Action.UserAddedColumn" type="System.Boolean, mscorlib, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+  <metadata name="Action.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
   <data name="Action.HeaderText" xml:space="preserve">
@@ -345,34 +345,34 @@ Press "Canc" keyboard key to remove shortcut.</value>
   <data name="Action.Width" type="System.Int32, mscorlib">
     <value>140</value>
   </data>
-  <metadata name="Shortcut.UserAddedColumn" type="System.Boolean, mscorlib, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+  <metadata name="Shortcut.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
   <data name="Shortcut.HeaderText" xml:space="preserve">
     <value>Shortcut</value>
   </data>
-  <data name="DGV.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+  <data name="DGVF.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
     <value>Fill</value>
   </data>
-  <data name="DGV.Location" type="System.Drawing.Point, System.Drawing">
+  <data name="DGVF.Location" type="System.Drawing.Point, System.Drawing">
     <value>3, 16</value>
   </data>
-  <data name="DGV.Size" type="System.Drawing.Size, System.Drawing">
+  <data name="DGVF.Size" type="System.Drawing.Size, System.Drawing">
     <value>548, 440</value>
   </data>
-  <data name="DGV.TabIndex" type="System.Int32, mscorlib">
+  <data name="DGVF.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
   </data>
-  <data name="&gt;&gt;DGV.Name" xml:space="preserve">
-    <value>DGV</value>
+  <data name="&gt;&gt;DGVF.Name" xml:space="preserve">
+    <value>DGVF</value>
   </data>
-  <data name="&gt;&gt;DGV.Type" xml:space="preserve">
-    <value>LaserGRBL.MyDatagridView, LaserGRBL, Version=3.1.2.0, Culture=neutral, PublicKeyToken=null</value>
+  <data name="&gt;&gt;DGVF.Type" xml:space="preserve">
+    <value>LaserGRBL.MyDatagridView, LaserGRBL, Version=5.6.0.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
-  <data name="&gt;&gt;DGV.Parent" xml:space="preserve">
+  <data name="&gt;&gt;DGVF.Parent" xml:space="preserve">
     <value>GB</value>
   </data>
-  <data name="&gt;&gt;DGV.ZOrder" xml:space="preserve">
+  <data name="&gt;&gt;DGVF.ZOrder" xml:space="preserve">
     <value>0</value>
   </data>
   <data name="GB.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
@@ -397,7 +397,7 @@ Press "Canc" keyboard key to remove shortcut.</value>
     <value>GB</value>
   </data>
   <data name="&gt;&gt;GB.Type" xml:space="preserve">
-    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;GB.Parent" xml:space="preserve">
     <value>tableLayoutPanel1</value>
@@ -424,7 +424,7 @@ Press "Canc" keyboard key to remove shortcut.</value>
     <value>tableLayoutPanel1</value>
   </data>
   <data name="&gt;&gt;tableLayoutPanel1.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TableLayoutPanel, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.TableLayoutPanel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;tableLayoutPanel1.Parent" xml:space="preserve">
     <value>$this</value>
@@ -435,7 +435,7 @@ Press "Canc" keyboard key to remove shortcut.</value>
   <data name="tableLayoutPanel1.LayoutSettings" type="System.Windows.Forms.TableLayoutSettings, System.Windows.Forms">
     <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="tableLayoutPanel2" Row="1" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="GB" Row="0" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;/Controls&gt;&lt;Columns Styles="AutoSize,0" /&gt;&lt;Rows Styles="Percent,100,AutoSize,0" /&gt;&lt;/TableLayoutSettings&gt;</value>
   </data>
-  <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+  <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
   <data name="$this.AutoScaleDimensions" type="System.Drawing.SizeF, System.Drawing">
@@ -530,18 +530,18 @@ Press "Canc" keyboard key to remove shortcut.</value>
     <value>Action</value>
   </data>
   <data name="&gt;&gt;Action.Type" xml:space="preserve">
-    <value>System.Windows.Forms.DataGridViewTextBoxColumn, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.DataGridViewTextBoxColumn, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;Shortcut.Name" xml:space="preserve">
     <value>Shortcut</value>
   </data>
   <data name="&gt;&gt;Shortcut.Type" xml:space="preserve">
-    <value>System.Windows.Forms.DataGridViewTextBoxColumn, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.DataGridViewTextBoxColumn, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;$this.Name" xml:space="preserve">
     <value>HotkeyManagerForm</value>
   </data>
   <data name="&gt;&gt;$this.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Form, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Form, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
 </root>

--- a/LaserGRBL/HotkeyManagerForm.resx
+++ b/LaserGRBL/HotkeyManagerForm.resx
@@ -351,28 +351,28 @@ Press "Canc" keyboard key to remove shortcut.</value>
   <data name="Shortcut.HeaderText" xml:space="preserve">
     <value>Shortcut</value>
   </data>
-  <data name="DGVF.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+  <data name="DGV.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
     <value>Fill</value>
   </data>
-  <data name="DGVF.Location" type="System.Drawing.Point, System.Drawing">
+  <data name="DGV.Location" type="System.Drawing.Point, System.Drawing">
     <value>3, 16</value>
   </data>
-  <data name="DGVF.Size" type="System.Drawing.Size, System.Drawing">
+  <data name="DGV.Size" type="System.Drawing.Size, System.Drawing">
     <value>548, 440</value>
   </data>
-  <data name="DGVF.TabIndex" type="System.Int32, mscorlib">
+  <data name="DGV.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
   </data>
-  <data name="&gt;&gt;DGVF.Name" xml:space="preserve">
-    <value>DGVF</value>
+  <data name="&gt;&gt;DGV.Name" xml:space="preserve">
+    <value>DGV</value>
   </data>
-  <data name="&gt;&gt;DGVF.Type" xml:space="preserve">
+  <data name="&gt;&gt;DGV.Type" xml:space="preserve">
     <value>LaserGRBL.MyDatagridView, LaserGRBL, Version=5.6.0.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
-  <data name="&gt;&gt;DGVF.Parent" xml:space="preserve">
+  <data name="&gt;&gt;DGV.Parent" xml:space="preserve">
     <value>GB</value>
   </data>
-  <data name="&gt;&gt;DGVF.ZOrder" xml:space="preserve">
+  <data name="&gt;&gt;DGV.ZOrder" xml:space="preserve">
     <value>0</value>
   </data>
   <data name="GB.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">

--- a/LaserGRBL/MainForm.cs
+++ b/LaserGRBL/MainForm.cs
@@ -17,1097 +17,1093 @@ using static Tools.ModifyProgressBarColor;
 
 namespace LaserGRBL
 {
-	public partial class MainForm : Form
-	{
-		private GrblCore Core;
-		private UsageStats.MessageData ToolBarMessage;
-		private bool IsBufferStuck = false;
-		private bool MultiRunShown = false;
-		private bool OrturWiFiShown;
-		private readonly string[] args;
-
-		public MainForm()
-		{
-			InitializeComponent();
-
-			MnOrtur.Visible = false;
-			MMn.Renderer = new MMnRenderer();
-
-
-			splitContainer1.FixedPanel = FixedPanel.Panel1;
-			splitContainer1.SplitterDistance = Settings.GetObject("MainForm Splitter Position", 260);
-
-			MnNotifyNewVersion.Checked = Settings.GetObject("Auto Update", true);
-			MnNotifyMinorVersion.Checked = Settings.GetObject("Auto Update Build", false);
-			MnNotifyPreRelease.Checked = Settings.GetObject("Auto Update Pre", false);
-
-			MnAutoUpdate.DropDown.Closing += MnAutoUpdateDropDown_Closing;
-
-			if (System.Threading.Thread.CurrentThread.Name == null)
-				System.Threading.Thread.CurrentThread.Name = "Main Thread";
-
-			using (SplashScreenForm f = new SplashScreenForm())
-				f.ShowDialog(this);
-
-			//build main communication object
-			Firmware ftype = Settings.GetObject("Firmware Type", Firmware.Grbl);
-			if (ftype == Firmware.Smoothie)
-				Core = new SmoothieCore(this, PreviewForm, JogForm);
-			else if (ftype == Firmware.Marlin)
-				Core = new MarlinCore(this, PreviewForm, JogForm);
-			else if (ftype == Firmware.VigoWork)
-				Core = new VigoCore(this, PreviewForm, JogForm);
-			else
-				Core = new GrblCore(this, PreviewForm, JogForm);
-			ExceptionManager.Core = Core;
-
-			if (true) //use multi instance trigger
-			{
-				SincroStart.StartListen(Core);
-				MultipleInstanceTimer.Enabled = true;
-			}
-
-			MnGrblConfig.Visible = Core.UIShowGrblConfig;
-			MnUnlock.Visible = Core.UIShowUnlockButtons;
-
-			MnGrbl.Text = Core.Type.ToString();
-
-			Core.MachineStatusChanged += OnMachineStatus;
-			Core.OnFileLoaded += OnFileLoaded;
-			Core.OnOverrideChange += RefreshOverride;
-			Core.IssueDetected += OnIssueDetected;
-
-			PreviewForm.SetCore(Core);
-			ConnectionForm.SetCore(Core);
-			JogForm.SetCore(Core);
-
-			GitHub.NewVersion += GitHub_NewVersion;
-
-			ColorScheme.CurrentScheme = Settings.GetObject("Color Schema", ColorScheme.Scheme.BlueLaser); ;
-			RefreshColorSchema(); //include RefreshOverride();
-			RefreshFormTitle();
-		}
-
-		public MainForm(string[] args) : this()
-		{
-			this.args = args;
-		}
-
-		private void MnAutoUpdateDropDown_Closing(object sender, ToolStripDropDownClosingEventArgs e)
-		{
-			if (e.CloseReason == ToolStripDropDownCloseReason.ItemClicked)
-			{
-				e.Cancel = true;
-			}
-		}
-
-		void OnIssueDetected(GrblCore.DetectedIssue issue)
-		{
-			if (!Settings.GetObject("Do not show Issue Detector", false))
-				IssueDetectorForm.CreateAndShowDialog(this, issue);
-		}
-
-		private void RefreshColorSchema()
-		{
-			MMn.BackColor = BackColor = StatusBar.BackColor = ColorScheme.FormBackColor;
-			MMn.ForeColor = ForeColor = ColorScheme.FormForeColor;
-			blueLaserToolStripMenuItem.Checked = ColorScheme.CurrentScheme == ColorScheme.Scheme.BlueLaser;
-			redLaserToolStripMenuItem.Checked = ColorScheme.CurrentScheme == ColorScheme.Scheme.RedLaser;
-			darkToolStripMenuItem.Checked = ColorScheme.CurrentScheme == ColorScheme.Scheme.Dark;
-			hackerToolStripMenuItem.Checked = ColorScheme.CurrentScheme == ColorScheme.Scheme.Hacker;
-			nightyToolStripMenuItem.Checked = ColorScheme.CurrentScheme == ColorScheme.Scheme.Nighty;
-			TTLinkToNews.LinkColor = ColorScheme.LinkColor;
-			TTLinkToNews.VisitedLinkColor = ColorScheme.VisitedLinkColor;
-			ConnectionForm.OnColorChange();
-			PreviewForm.OnColorChange();
-			RefreshOverride();
-		}
-
-		void GitHub_NewVersion(Version current, GitHub.OnlineVersion available, Exception error)
-		{
-			if (InvokeRequired)
-			{
-				Invoke(new GitHub.NewVersionDlg(GitHub_NewVersion), current, available, error);
-			}
-			else
-			{
-				if (error != null)
-					MessageBox.Show(this, "Cannot check for new version, please verify http://lasergrbl.com manually.", "Software info", MessageBoxButtons.OK, MessageBoxIcon.Error, MessageBoxDefaultButton.Button1);
-				else if (available != null)
-					NewVersionForm.CreateAndShowDialog(current, available, this);
-				else
-					MessageBox.Show(this, "You have the most updated version!", "Software info", MessageBoxButtons.OK, MessageBoxIcon.Information, MessageBoxDefaultButton.Button1);
-
-			}
-		}
-
-		private void MainForm_Load(object sender, EventArgs e)
-		{
-			bool canrun = Settings.GetObject("IsDisclamerAccepted", false);
-			if (!canrun)
-			{
-				using (LegalDisclaimer lds = new LegalDisclaimer())
-				{
-					lds.ShowDialog();
-					if (lds.accepted)
-					{
-						canrun = true;
-						Settings.SetObject("IsDisclamerAccepted", true);
-					}
-				}
-			}
-
-			if (canrun)
-			{
-				UpdateTimer.Enabled = true;
-
-				if (Settings.GetObject("Auto Update", true))
-					GitHub.CheckVersion(false);
-
-				SuspendLayout();
-				//restore last size and position
-				Object[] msp = Settings.GetObject<Object[]>("Mainform Size and Position", null);
-				FormWindowState state = msp == null ? FormWindowState.Maximized : (FormWindowState)msp[2] != FormWindowState.Minimized ? (FormWindowState)msp[2] : FormWindowState.Maximized;
-				if (state == FormWindowState.Normal)
-				{ WindowState = state; Size = (Size)msp[0]; Location = (Point)msp[1]; }
-				ResumeLayout();
-
-				ManageMessage();
-				ManageCommandLineArgs(args);
-			}
-			else
-			{
-				Close();
-			}
-		}
-
-		private void ManageCommandLineArgs(string[] args)
-		{
-			if (args != null && args.Length == 1)
-			{
-				string filename = args[0];
-				if (System.IO.File.Exists(filename))
-				{
-					Application.DoEvents();
-
-					if (System.IO.Path.GetExtension(filename).ToLower() == ".zbn") //zipped button
-					{
-						PreviewForm.ImportButton(filename);
-					}
-					else
-					{
-						if (Core.CanLoadNewFile)
-							Core.OpenFile(this, filename, false);
-						else
-							MessageBox.Show(Strings.MsgboxCannotOpenFileNow);
-					}
-				}
-			}
-		}
-
-		private void ManageMessage()
-		{
-			try
-			{
-				foreach (UsageStats.MessageData M in UsageStats.Messages.GetMessages(UsageStats.MessageData.MessageTypes.AutoLink))
-				{
-					Tools.Utils.OpenLink(M.Content);
-					UsageStats.Messages.ClearMessage(M);
-				}
-
-				ToolBarMessage = UsageStats.Messages.GetMessage(UsageStats.MessageData.MessageTypes.ToolbarLink);
-				if (ToolBarMessage != null && ToolBarMessage.Title != null && ToolBarMessage.Content != null)
-				{
-					TTLinkToNews.Text = ToolBarMessage.Title;
-					TTLinkToNews.Enabled = true;
-
-					this.TTLinkToNews.LinkBehavior = System.Windows.Forms.LinkBehavior.HoverUnderline;
-				}
-			}
-			catch (Exception ex) { System.Diagnostics.Debug.WriteLine(ex); }
-		}
-
-		void OnFileLoaded(long elapsed, string filename)
-		{
-			if (InvokeRequired)
-			{
-				Invoke(new GrblFile.OnFileLoadedDlg(OnFileLoaded), elapsed, filename);
-			}
-			else
-			{
-				TimerUpdate();
-				//TTTFile.Text = System.IO.Path.GetFileName(filename);
-				TTTLines.Text = Core.LoadedFile.Count.ToString();
-				//TTTLoadedIn.Text = elapsed.ToString() + " ms";
-				TTTEstimated.Text = Tools.Utils.TimeSpanToString(Core.LoadedFile.EstimatedTime, Tools.Utils.TimePrecision.Second, Tools.Utils.TimePrecision.Second, " ,", true);
-			}
-		}
-
-
-		bool PrevConnected = false;
-		void OnMachineStatus()
-		{
-			TimerUpdate();
-
-			if (Core.MachineStatus == GrblCore.MacStatus.Disconnected && Core.FailedConnectionCount >= 3)
-			{
-				string url = null;
-				ComWrapper.WrapperType wt = Settings.GetObject("ComWrapper Protocol", ComWrapper.WrapperType.UsbSerial);
-
-				if (wt == ComWrapper.WrapperType.UsbSerial || wt == ComWrapper.WrapperType.UsbSerial2)
-					url = "https://lasergrbl.com/usage/arduino-connection/";
-				else if (wt == ComWrapper.WrapperType.Telnet || wt == ComWrapper.WrapperType.LaserWebESP8266)
-					url = "https://lasergrbl.com/usage/wifi-with-esp8266/";
-
-				if (url != null)
-					MessageBox.Show(this, Strings.ProblemConnectingText, Strings.ProblemConnectingTitle, MessageBoxButtons.OK, MessageBoxIcon.Information, MessageBoxDefaultButton.Button1, 0, url);
-			}
-
-			if (Core.IsConnected && !PrevConnected)
-			{
-				LaserLifeHandler.OnConnect(this);
-			}
-			if (!Core.IsConnected && PrevConnected)
-			{
-				LaserLifeHandler.OnDisconnect();
-			}
-
-			PrevConnected = Core.IsConnected;
-
-		}
-		void MainFormFormClosing(object sender, FormClosingEventArgs e)
-		{
-			if (Core.InProgram && System.Windows.Forms.MessageBox.Show(Strings.ExitAnyway, Strings.WarnMessageBoxHeader, MessageBoxButtons.YesNo, MessageBoxIcon.Warning, MessageBoxDefaultButton.Button2) != System.Windows.Forms.DialogResult.Yes)
-				e.Cancel = true;
-
-			if (!e.Cancel)
-			{
-				SincroStart.StopListen();
-				Core.Exiting();
-				Settings.SetObject("Mainform Size and Position", new object[] { Size, Location, WindowState });
-				Settings.Exiting();
-
-				UsageStats.SaveFile(Core);
-			}
-		}
-
-
-		private void UpdateTimer_Tick(object sender, EventArgs e)
-		{
-			long foo = HiResTimer.TotalNano; //ensure call TotalNano to be able to detect and fix sleep/hibernation
-			TimerUpdate();
-			ConnectionForm.TimerUpdate();
-			PreviewForm.TimerUpdate();
-			JogForm.Enabled = Core.JogEnabled;
-			PromptOrturWiFi();
-		}
-
-		private void PromptOrturWiFi()
-		{
-			if (!OrturWiFiShown && !Settings.GetObject("Suppress Ortur WiFI Message", false) && Core.GrblVersion != null && Core.GrblVersion.IsLuckyOrturWiFi && !IsConfiguredForWiFi() && Core.CanReadWriteConfig)
-			{
-				OrturWiFiShown = true;
-
-				using (OrturWiFiConfigPrompt F = new OrturWiFiConfigPrompt(Core))
-				{
-					if (F.ShowDialog(this) == DialogResult.OK)
-						ShowWiFiConfig();
-				}
-
-			}
-		}
-
-		private void ShowWiFiConfig()
-		{
-			using (OrturWiFiConfig F2 = new OrturWiFiConfig(Core))
-			{
-				if (F2.ShowDialog(this) == DialogResult.OK && Core.DetectedIP != null)
-				{
-					ConnectionForm.ConfigFromOrtur($"{Core.DetectedIP}:{GrblCore.Configuration.TelnetPort}");
-					Settings.SetObject("ComWrapper Protocol", ComWrapper.WrapperType.Telnet);
-					Core.CloseCom(true);
-				}
-
-			}
-		}
-
-		private void TimerUpdate()
-		{
-			SuspendLayout();
-			TTTStatus.Text = GrblCore.TranslateEnum(Core.MachineStatus);
-
-			if (Core.InProgram)
-				TTTEstimated.Text = Tools.Utils.TimeSpanToString(Core.ProjectedTime, Tools.Utils.TimePrecision.Second, Tools.Utils.TimePrecision.Second, " ,", true);
-			else
-				TTTEstimated.Text = Tools.Utils.TimeSpanToString(Core.LoadedFile.EstimatedTime, Tools.Utils.TimePrecision.Second, Tools.Utils.TimePrecision.Second, " ,", true);
-
-			if (Core.InProgram)
-				TTLEstimated.Text = Strings.MainFormProjectedTime;
-			else
-				TTLEstimated.Text = Strings.MainFormEstimatedTime;
-
-			MnFileOpen.Enabled = Core.CanLoadNewFile;
-			MnSaveProject.Enabled = MnAdvancedSave.Enabled = MnSaveProgram.Enabled = Core.HasProgram;
-			MnFileSend.Enabled = Core.CanSendFile;
-			MnStartFromPosition.Enabled = Core.CanSendFile;
-			MnRunMulti.Enabled = Core.CanSendFile || Core.CanResumeHold || Core.CanFeedHold;
-			MnGrblConfig.Enabled = true;
-			//MnExportConfig.Enabled = Core.CanImportExport;
-			//MnImportConfig.Enabled = Core.CanImportExport;
-			MnGrblReset.Enabled = Core.CanResetGrbl;
-
-			MNEsp8266.Visible = false;// (Settings.GetObject("ComWrapper Protocol", ComWrapper.WrapperType.UsBSerial)) == ComWrapper.WrapperType.LaserWebESP8266;
-
-			MnConnect.Visible = !Core.IsConnected;
-			MnDisconnect.Visible = Core.IsConnected;
-
-			MnGoHome.Visible = GrblCore.Configuration.HomingEnabled;
-			MnGoHome.Enabled = Core.CanDoHoming;
-			MnUnlock.Enabled = Core.CanUnlock;
-
-			TTOvG0.Visible = Core.SupportOverride;
-			TTOvG1.Visible = Core.SupportOverride;
-			TTOvS.Visible = Core.SupportOverride;
-			spacer.Visible = Core.SupportOverride;
-
-			MnWiFiDiscovery.Visible = IsConfiguredForWiFi();
-			MnWiFiDiscovery.Enabled = !Core.IsConnected;
-
-			ComWrapper.WrapperType wr = Settings.GetObject("ComWrapper Protocol", ComWrapper.WrapperType.UsbSerial);
-
-			MnSeparatorConfigWiFi.Visible = MnConfigureOrturWiFi.Visible = Core.GrblVersion != null && (wr == ComWrapper.WrapperType.UsbSerial || wr == ComWrapper.WrapperType.UsbSerial2) && Core.GrblVersion.IsLuckyOrturWiFi;
-			MnConfigureOrturWiFi.Enabled = MnConfigureOrturWiFi.Visible && Core.CanReadWriteConfig;
-
-			switch (Core.MachineStatus)
-			{
-				//Disconnected, Connecting, Idle, *Run, *Hold, *Door, Home, *Alarm, *Check, *Jog
-
-				case GrblCore.MacStatus.Alarm:
-					TTTStatus.BackColor = Color.Red;
-					TTTStatus.ForeColor = Color.White;
-					break;
-				case GrblCore.MacStatus.Door:
-				case GrblCore.MacStatus.Hold:
-				case GrblCore.MacStatus.Cooling:
-				case GrblCore.MacStatus.AutoHold:
-					TTTStatus.BackColor = Color.DarkOrange;
-					TTTStatus.ForeColor = Color.Black;
-					break;
-				case GrblCore.MacStatus.Jog:
-				case GrblCore.MacStatus.Run:
-				case GrblCore.MacStatus.Check:
-					TTTStatus.BackColor = Color.LightGreen;
-					TTTStatus.ForeColor = Color.Black;
-					break;
-				default:
-					TTTStatus.BackColor = ColorScheme.FormBackColor;
-					TTTStatus.ForeColor = ColorScheme.FormForeColor;
-					break;
-			}
-
-			PbBuffer.Maximum = Core.BufferSize;
-			PbBuffer.Value = Core.UsedBuffer;
-			PbBuffer.ToolTipText = $"Buffer: {Core.UsedBuffer}/{Core.BufferSize} Free:{Core.FreeBuffer}";
-
-			bool stuck = Core.IsBufferStuck();
-			if (stuck != IsBufferStuck)
-			{
-				IsBufferStuck = stuck;
-				PbBuffer.ProgressBar.SetState(stuck ? 2 : 1);
-				BtnUnlockFromStuck.Enabled = stuck;
-			}
-
-			MnOrtur.Visible = Core.IsOrturBoard;
-
-			string NewTTLLText = $"{LaserLifeHandler.GetCurrentTime().TotalHours.ToString("0.0", System.Globalization.CultureInfo.InvariantCulture)}h";
-			if (TTlaserLife.Text != NewTTLLText) TTlaserLife.Text = NewTTLLText; //prevent tooltip flickering
-
-			ResumeLayout();
-		}
-
-		private bool IsConfiguredForWiFi()
-		{
-			ComWrapper.WrapperType wt = Settings.GetObject("ComWrapper Protocol", ComWrapper.WrapperType.UsbSerial);
-			return (wt == ComWrapper.WrapperType.LaserWebESP8266 || wt == ComWrapper.WrapperType.Telnet);
-		}
-
-		private void RefreshFormTitle()
-		{
-			string FormTitle = string.Format("LaserGRBL v{0}", Program.CurrentVersion.ToString(3));
-
-			if (Core.Type != Firmware.Grbl)
-				FormTitle = FormTitle + $" (for {Core.Type})";
-
-
-			if (Text != FormTitle) Text = FormTitle;
-		}
-
-		void ExitToolStripMenuItemClick(object sender, EventArgs e)
-		{
-			Close();
-		}
-
-		private void MnFileOpen_Click(object sender, EventArgs e)
-		{
-			Project.ClearSettings();
-			Core.OpenFile(this);
-		}
-
-		private void MnFileSend_Click(object sender, EventArgs e)
-		{
-			Core.RunProgram(this);
-		}
-
-		private void MnGrblReset_Click(object sender, EventArgs e)
-		{
-			Core.GrblReset();
-		}
-
-		void RefreshOverride()
-		{
-			SuspendLayout();
-			TTOvG0.Text = string.Format("G0 [{0:0.00}x]", Core.OverrideG0 / 100.0);
-			TTOvG0.BackColor = Core.OverrideG0 > 100 ? Color.LightPink : (Core.OverrideG0 < 100 ? Color.LightBlue : ColorScheme.FormBackColor);
-			TTOvG0.ForeColor = Core.OverrideG0 != 100 ? Color.Black : ColorScheme.FormForeColor;
-			TTOvG1.Text = string.Format("G1 [{0:0.00}x]", Core.OverrideG1 / 100.0);
-			TTOvG1.BackColor = Core.OverrideG1 > 100 ? Color.LightPink : (Core.OverrideG1 < 100 ? Color.LightBlue : ColorScheme.FormBackColor);
-			TTOvG1.ForeColor = Core.OverrideG1 != 100 ? Color.Black : ColorScheme.FormForeColor;
-			TTOvS.Text = string.Format("S [{0:0.00}x]", Core.OverrideS / 100.0);
-			TTOvS.BackColor = Core.OverrideS > 100 ? Color.LightPink : (Core.OverrideS < 100 ? Color.LightBlue : ColorScheme.FormBackColor);
-			TTOvS.ForeColor = Core.OverrideS != 100 ? Color.Black : ColorScheme.FormForeColor;
-
-			ResumeLayout();
-		}
-		void TTOvClick(object sender, EventArgs e)
-		{
-			GetOvMenu().Show(Cursor.Position, ToolStripDropDownDirection.AboveLeft);
-		}
-
-
-
-		internal virtual System.Windows.Forms.ContextMenuStrip GetOvMenu()
-		{
-			System.Windows.Forms.ContextMenuStrip CM = new System.Windows.Forms.ContextMenuStrip();
-			CM.Items.Add(new ToolStripTraceBarItem(Core, 2));
-			CM.Items.Add(new ToolStripTraceBarItem(Core, 1));
-			CM.Items.Add(new ToolStripTraceBarItem(Core, 0));
-			CM.Width = 150;
-
-			return CM;
-		}
-
-		/// <summary>
-		/// Adds trackbar to toolstrip stuff
-		/// </summary>
-		[System.Windows.Forms.Design.ToolStripItemDesignerAvailability(System.Windows.Forms.Design.ToolStripItemDesignerAvailability.ToolStrip | System.Windows.Forms.Design.ToolStripItemDesignerAvailability.StatusStrip)]
-		public class ToolStripTraceBarItem : System.Windows.Forms.ToolStripControlHost
-		{
-			public ToolStripTraceBarItem(GrblCore core, int function)
-				: base(new UserControls.LabelTB(core, function))
-			{
-				Control.Dock = System.Windows.Forms.DockStyle.Fill;
-			}
-		}
-
-		private void MnGoHome_Click(object sender, EventArgs e)
-		{
-			Core.SendHomingCommand();
-		}
-
-		private void MnUnlock_Click(object sender, EventArgs e)
-		{
-			Core.SendUnlockCommand();
-		}
-
-		private void MnConnect_Click(object sender, EventArgs e)
-		{
-			Core.OpenCom();
-		}
-
-		private void MnDisconnect_Click(object sender, EventArgs e)
-		{
-			if (!(Core.InProgram && System.Windows.Forms.MessageBox.Show(Strings.DisconnectAnyway, Strings.WarnMessageBoxHeader, MessageBoxButtons.YesNo, MessageBoxIcon.Warning, MessageBoxDefaultButton.Button2) != System.Windows.Forms.DialogResult.Yes))
-				Core.CloseCom(true);
-		}
-		void MnSaveProgramClick(object sender, EventArgs e)
-		{
-			Core.SaveProgram(this, false, false, false, 1, false);
-		}
-
-		private void MnAdvancedSave_Click(object sender, EventArgs e)
-		{
-			SaveOptionForm.CreateAndShowDialog(this, Core);
-		}
-
-		private void MnSaveProject_Click(object sender, EventArgs e)
-		{
-			Core.SaveProject(this);
-		}
-
-		private void MNEnglish_Click(object sender, EventArgs e)
-		{
-			SetLanguage(new System.Globalization.CultureInfo("en"));
-		}
-
-		private void MNItalian_Click(object sender, EventArgs e)
-		{
-			SetLanguage(new System.Globalization.CultureInfo("it"));
-		}
-
-		private void MNSpanish_Click(object sender, EventArgs e)
-		{
-			SetLanguage(new System.Globalization.CultureInfo("es"));
-		}
-
-		private void SetLanguage(System.Globalization.CultureInfo ci)
-		{
-			if (ci != null)
-				Settings.SetObject("User Language", ci);
-			else
-				Settings.DeleteObject("User Language");
-
-			if (MessageBox.Show(Strings.LanguageRequireRestartNow, Strings.LanguageRequireRestart, MessageBoxButtons.OKCancel) == DialogResult.OK)
-				Application.Restart();
-		}
-
-		private void helpOnLineToolStripMenuItem_Click(object sender, EventArgs e)
-		{
-			Core.HelpOnLine();
-		}
-
-		private void aboutToolStripMenuItem_Click(object sender, EventArgs e)
-		{
-			Tools.Utils.OpenLink(@"https://lasergrbl.com/faq/");
-		}
-
-		private void splitContainer1_SplitterMoved(object sender, SplitterEventArgs e)
-		{
-			Settings.SetObject("MainForm Splitter Position", splitContainer1.SplitterDistance);
-		}
-
-		private void settingsToolStripMenuItem_Click(object sender, EventArgs e)
-		{
-			SettingsForm.CreateAndShowDialog(this, Core);
-		}
-
-		private void openSessionLogToolStripMenuItem_Click(object sender, EventArgs e)
-		{
-			if (Logger.ExistLog)
-				Logger.ShowLog();
-		}
-
-		private void toolStripMenuItem4_DropDownOpening(object sender, EventArgs e)
-		{
-			openSessionLogToolStripMenuItem.Enabled = Logger.ExistLog;
-			activateExtendedLogToolStripMenuItem.Checked = ComWrapper.ComLogger.Enabled;
-		}
-
-		private void MNFrench_Click(object sender, EventArgs e)
-		{
-			SetLanguage(new System.Globalization.CultureInfo("fr"));
-		}
-
-		private void MNGerman_Click(object sender, EventArgs e)
-		{
-			SetLanguage(new System.Globalization.CultureInfo("de"));
-		}
-
-		private void MNDanish_Click(object sender, EventArgs e)
-		{
-			SetLanguage(new System.Globalization.CultureInfo("da"));
-		}
-
-		private void MNBrazilian_Click(object sender, EventArgs e)
-		{
-			SetLanguage(new System.Globalization.CultureInfo("pt-BR"));
-		}
-
-		private void russianToolStripMenuItem_Click(object sender, EventArgs e)
-		{
-			SetLanguage(new System.Globalization.CultureInfo("ru"));
-		}
-
-		private void chineseToolStripMenuItem_Click(object sender, EventArgs e)
-		{
-			SetLanguage(new System.Globalization.CultureInfo("zh-CN"));
-		}
-
-		private void slovakToolStripMenuItem_Click(object sender, EventArgs e)
-		{
-			SetLanguage(new System.Globalization.CultureInfo("sk-SK"));
-		}
-
-		private void MNGrblEmulator_Click(object sender, EventArgs e)
-		{
-			GrblEmulator.WebSocketEmulator.Start();
-		}
-
-		private void blueLaserToolStripMenuItem_Click(object sender, EventArgs e)
-		{
-			SetSchema(ColorScheme.Scheme.BlueLaser);
-		}
-
-		private void redLaserToolStripMenuItem_Click(object sender, EventArgs e)
-		{
-			SetSchema(ColorScheme.Scheme.RedLaser);
-		}
-
-		private void darkToolStripMenuItem_Click(object sender, EventArgs e)
-		{
-			SetSchema(ColorScheme.Scheme.Dark);
-		}
-
-		private void hackerToolStripMenuItem_Click(object sender, EventArgs e)
-		{
-			SetSchema(ColorScheme.Scheme.Hacker);
-		}
-
-		private void nightyToolStripMenuItem_Click(object sender, EventArgs e)
-		{
-			SetSchema(ColorScheme.Scheme.Nighty);
-		}
-
-		private void SetSchema(ColorScheme.Scheme schema)
-		{
-			Settings.SetObject("Color Schema", schema);
-			ColorScheme.CurrentScheme = schema;
-			RefreshColorSchema();
-		}
-
-		private void grblConfigurationToolStripMenuItem_Click(object sender, EventArgs e)
-		{
-			GrblConfig.CreateAndShowDialog(this, Core);
-		}
-
-		private void donateToolStripMenuItem_Click(object sender, EventArgs e)
-		{
-			Tools.Utils.OpenLink(@"https://lasergrbl.com/donate");
-		}
-
-
-		protected override void OnKeyUp(KeyEventArgs e)
-		{
-			mLastkeyData = Keys.None;
-			Core.ManageHotKeys(this, Keys.None);
-			base.OnKeyUp(e);
-		}
-
-		Keys mLastkeyData = Keys.None;
-		protected override bool ProcessCmdKey(ref Message msg, Keys keyData)
-		{
-			if (keyData != mLastkeyData)
-			{
-				mLastkeyData = keyData;
-				return Core.ManageHotKeys(this, keyData);
-			}
-			else
-			{
-				return base.ProcessCmdKey(ref msg, keyData);
-			}
-		}
-
-		private void MnReOpenFile_Click(object sender, EventArgs e)
-		{
-			Project.ClearSettings();
-			Core.ReOpenFile(this);
-		}
-
-
-		private void fileToolStripMenuItem_DropDownOpening(object sender, EventArgs e)
-		{
-			MnReOpenFile.Enabled = Core.CanReOpenFile;
-		}
-
-		private void MnHotkeys_Click(object sender, EventArgs e)
-		{
-			HotkeyManagerForm.CreateAndShowDialog(this, Core);
-		}
-
-
-		private void AwakeTimer_Tick(object sender, EventArgs e)
-		{
-			if (Core != null && Core.InProgram)
-				Tools.WinAPI.SignalActvity();
-		}
-
-		private void MnStartFromPosition_Click(object sender, EventArgs e)
-		{
-			Core.RunProgramFromPosition(this);
-		}
-
-		private void MnFileAppend_Click(object sender, EventArgs e)
-		{
-			Core.OpenFile(this, null, true);
-		}
-
-		private void hungarianToolStripMenuItem_Click(object sender, EventArgs e)
-		{
-			SetLanguage(new System.Globalization.CultureInfo("hu-HU"));
-		}
-
-		private void czechToolStripMenuItem_Click(object sender, EventArgs e)
-		{
-			SetLanguage(new System.Globalization.CultureInfo("cs-CZ"));
-		}
-
-		private void installCH340DriverToolStripMenuItem_Click(object sender, EventArgs e)
-		{
-			try
-			{
-				string fname = System.IO.Path.Combine(GrblCore.ExePath, "Driver\\CH341SER.EXE");
-				System.Diagnostics.Process.Start(fname);
-			}
-			catch { Tools.Utils.OpenLink("https://www.google.it/search?q=ch340+drivers"); }
-		}
-
-		private void flashGrblFirmwareToolStripMenuItem_Click(object sender, EventArgs e)
-		{
-			FlashGrbl form = new FlashGrbl();
-			form.ShowDialog(this);
-			if (form.retval != int.MinValue)
-			{
-				if (form.retval == 0)
-					MessageBox.Show("Firmware flashed succesfull!", "Result", MessageBoxButtons.OK, MessageBoxIcon.Information);
-				else
-					MessageBox.Show("Error: cannot flash firmware.", "Result", MessageBoxButtons.OK, MessageBoxIcon.Error);
-			}
-
-			form.Dispose();
-
-		}
-
-		private void toolsToolStripMenuItem_DropDownOpening(object sender, EventArgs e)
-		{
-			flashGrblFirmwareToolStripMenuItem.Enabled = (Core.MachineStatus == GrblCore.MacStatus.Disconnected);
-		}
-
-		private void activateExtendedLogToolStripMenuItem_Click(object sender, EventArgs e)
-		{
-			if (!ComWrapper.ComLogger.Enabled)
-			{
-				using (SaveFileDialog sfd = new System.Windows.Forms.SaveFileDialog())
-				{
-					sfd.InitialDirectory = Environment.GetFolderPath(Environment.SpecialFolder.Desktop);
-					sfd.Filter = "Communication log|*.txt";
-					sfd.AddExtension = true;
-					sfd.OverwritePrompt = false;
-					sfd.FileName = "comlog.txt";
-					sfd.Title = "Select extended log filename";
-
-					DialogResult dialogResult = DialogResult.Cancel;
-					try
-					{
-						dialogResult = sfd.ShowDialog(this);
-					}
-					catch (System.Runtime.InteropServices.COMException)
-					{
-						sfd.AutoUpgradeEnabled = false;
-						dialogResult = sfd.ShowDialog(this);
-					}
-
-					if (dialogResult == DialogResult.OK && sfd.FileName != null)
-					{
-						string message = ComWrapper.ComLogger.StartLog(sfd.FileName);
-						Logger.LogMessage("ComLog", message);
-					}
-				}
-			}
-			else
-			{
-				string message = ComWrapper.ComLogger.StopLog();
-				if (message != null) Logger.LogMessage("ComLog", message);
-			}
-		}
-
-		private DispatcherTimer dropDispatcherTimer;
-		private string droppedFile;
-
-		private void MainForm_DragEnter(object sender, DragEventArgs e)
-		{
-			if (droppedFile == null)
-			{
-				if (e.Data.GetDataPresent(DataFormats.FileDrop)) e.Effect = DragDropEffects.Copy;
-			}
-		}
-
-		private void MainForm_DragDrop(object sender, DragEventArgs e)
-		{
-			if (droppedFile == null)
-			{
-				string[] files = (string[])e.Data.GetData(DataFormats.FileDrop);
-				if (files.Length == 1)
-				{
-					droppedFile = files[0];
-
-					// call via DispatcherTimer to unblock the source of the drag-event (e.g. Explorer-Window)
-					if (dropDispatcherTimer == null)
-					{
-						this.dropDispatcherTimer = new DispatcherTimer();
-						this.dropDispatcherTimer.Interval = TimeSpan.FromSeconds(0.5);
-						this.dropDispatcherTimer.Tick += new EventHandler(dropDispatcherTimer_Tick);
-					}
-					this.dropDispatcherTimer.Start();
-				}
-			}
-		}
-
-		void dropDispatcherTimer_Tick(object sender, EventArgs e)
-		{
-			if (this.droppedFile != null)
-			{
-				Core.OpenFile(this, this.droppedFile);
-				this.droppedFile = null;
-				dropDispatcherTimer.Stop();
-			}
-		}
-
-		private void licenseToolStripMenuItem_Click(object sender, EventArgs e)
-		{
-			LicenseForm.CreateAndShowDialog(this);
-		}
-
-		private void MnNotifyNewVersion_Click(object sender, EventArgs e)
-		{
-			MnNotifyNewVersion.Checked = !MnNotifyNewVersion.Checked;
-			Settings.SetObject("Auto Update", MnNotifyNewVersion.Checked);
-
-			//if (MnNotifyNewVersion.Checked)
-			//	GitHub.CheckVersion();
-		}
-
-		private void MnNotifyNewVersion_CheckedChanged(object sender, EventArgs e)
-		{
-			if (!MnNotifyNewVersion.Checked) //disabilita il minor update
-			{
-				MnNotifyMinorVersion.Enabled = false;
-				MnNotifyMinorVersion.Checked = false;
-				MnNotifyPreRelease.Enabled = false;
-				MnNotifyPreRelease.Checked = false;
-				Settings.SetObject("Auto Update Build", false);
-				Settings.SetObject("Auto Update Pre", false);
-			}
-			else
-			{
-				MnNotifyMinorVersion.Enabled = true;
-				MnNotifyMinorVersion.Checked = Settings.GetObject("Auto Update Build", false);
-				MnNotifyPreRelease.Enabled = true;
-				MnNotifyPreRelease.Checked = Settings.GetObject("Auto Update Pre", false);
-			}
-		}
-
-		private void MnNotifyMinorVersion_Click(object sender, EventArgs e)
-		{
-			MnNotifyMinorVersion.Checked = !MnNotifyMinorVersion.Checked;
-			Settings.SetObject("Auto Update Build", MnNotifyMinorVersion.Checked);
-
-			//if (MnNotifyNewVersion.Checked && MnNotifyMinorVersion.Checked)
-			//	GitHub.CheckVersion();
-		}
-
-		private void MnNotifyPreRelease_Click(object sender, EventArgs e)
-		{
-			MnNotifyPreRelease.Checked = !MnNotifyPreRelease.Checked;
-			Settings.SetObject("Auto Update Pre", MnNotifyPreRelease.Checked);
-
-			//if (MnNotifyNewVersion.Checked && MnNotifyPreRelease.Checked)
-			//	GitHub.CheckVersion();
-		}
-
-		private void MnCheckNow_Click(object sender, EventArgs e)
-		{
-			questionMarkToolStripMenuItem.HideDropDown();
-			GitHub.CheckVersion(true);
-		}
-
-		private void MnMaterialDB_Click(object sender, EventArgs e)
-		{
-			PSHelper.PSEditorForm.CreateAndShowDialog(this);
-		}
-
-		private void polishToolStripMenuItem_Click(object sender, EventArgs e)
-		{
-			SetLanguage(new System.Globalization.CultureInfo("pl-PL"));
-		}
-
-		private void orturSupportGroupToolStripMenuItem_Click(object sender, EventArgs e)
-		{
-			Tools.Utils.OpenLink(@"https://lasergrbl.com/orturfacebook/");
-		}
-
-		private void orturWebsiteToolStripMenuItem_Click(object sender, EventArgs e)
-		{
-			Tools.Utils.OpenLink(@"https://lasergrbl.com/orturwebsite/");
-		}
-
-		private void traditionalChineseToolStripMenuItem_Click(object sender, EventArgs e)
-		{
-			SetLanguage(new System.Globalization.CultureInfo("zh-TW"));
-		}
-
-		private void youtubeChannelToolStripMenuItem_Click(object sender, EventArgs e)
-		{
-			Tools.Utils.OpenLink(@"https://lasergrbl.com/orturYTchannel/");
-		}
-
-		private void firmwareToolStripMenuItem_Click(object sender, EventArgs e)
-		{
-			Tools.Utils.OpenLink(@"https://lasergrbl.com/ortur-firmware/");
-		}
-
-		private void manualsDownloadToolStripMenuItem_Click(object sender, EventArgs e)
-		{
-			Tools.Utils.OpenLink(@"https://lasergrbl.com/ortur-manuals/");
-		}
-
-		private void MultipleInstanceTimer_Tick(object sender, EventArgs e)
-		{
-			MultipleInstanceTimer.Interval = 5000;
-			MnRunMulti.Visible = MnRunMultiSep.Visible = SincroStart.Running() && System.Diagnostics.Process.GetProcessesByName(System.IO.Path.GetFileNameWithoutExtension(System.Reflection.Assembly.GetEntryAssembly().Location)).Length > 1;
-		}
-
-		private void MnRunMulti_Click(object sender, EventArgs e)
-		{
-			if (MultiRunShown || MessageBox.Show(this, "Warning: this command will start/resume all job in any running LaserGRBL instance!", "Warning", MessageBoxButtons.OKCancel, MessageBoxIcon.Warning) == DialogResult.OK)
-			{
-				SincroStart.Signal();
-				MultiRunShown = true;
-			}
-		}
-
-		private void orturSupportAndFeedbackToolStripMenuItem_Click(object sender, EventArgs e)
-		{
-			Tools.Utils.OpenLink(@"https://lasergrbl.com/ortursupport/");
-		}
-
-		private void TTLinkToNews_Click(object sender, EventArgs e)
-		{
-			if (ToolBarMessage != null && ToolBarMessage.Title != null && ToolBarMessage.Content != null)
-			{
-				Tools.Utils.OpenLink(ToolBarMessage.Content);
-				UsageStats.Messages.ClearMessage(ToolBarMessage);
-			}
-		}
-
-		private void MnWiFiDiscovery_Click(object sender, EventArgs e)
-		{
-			ConnectionForm.ConfigFromDiscovery(WiFiDiscovery.DiscoveryForm.CreateAndShowDialog(this));
-		}
-
-		private void facebookCommunityToolStripMenuItem_Click(object sender, EventArgs e)
-		{
-			Tools.Utils.OpenLink(@"https://www.facebook.com/groups/486886768471991");
-		}
-
-		private void greekToolStripMenuItem_Click(object sender, EventArgs e)
-		{
-			SetLanguage(new System.Globalization.CultureInfo("el-GR"));
-		}
-
-		private void turkishToolStripMenuItem_Click(object sender, EventArgs e)
-		{
-			SetLanguage(new System.Globalization.CultureInfo("tr-TR"));
-		}
-
-		private void BtnUnlockFromStuck_Click(object sender, EventArgs e)
-		{
-			if (MessageBox.Show(Strings.WarnBufferStuckUnlockText, Strings.WarnBufferStuckUnlockTitle, MessageBoxButtons.OKCancel, MessageBoxIcon.Information, MessageBoxDefaultButton.Button1, 0, "http://lasergrbl.com/faq", "issues") == DialogResult.OK)
-			{
-				Core.UnlockFromBufferStuck(false);
-			}
-		}
-
-		private void romanianToolStripMenuItem_Click(object sender, EventArgs e)
-		{
-			SetLanguage(new System.Globalization.CultureInfo("ro-RO"));
-		}
-
-		private void dutchToolStripMenuItem_Click(object sender, EventArgs e)
-		{
-			SetLanguage(new System.Globalization.CultureInfo("nl-NL"));
-		}
-
-		private void ukrainianToolStripMenuItem_Click(object sender, EventArgs e)
-		{
-			SetLanguage(new System.Globalization.CultureInfo("uk"));
-		}
-
-		private void TTTStatus_DoubleClick(object sender, EventArgs e)
-		{
-			Tools.Utils.OpenLink(@"https://lasergrbl.com/usage/machine-status/");
-		}
-
-		private void MnConfigureOrturWiFi_Click(object sender, EventArgs e)
-		{
-			ShowWiFiConfig();
-		}
-
-		private void TTlaserLife_Click(object sender, EventArgs e)
-		{
-			LaserUsage.CreateAndShowDialog(this, Core);
-		}
-
-		private void laserUsageStatsToolStripMenuItem_Click(object sender, EventArgs e)
-		{
-			LaserUsage.CreateAndShowDialog(this, Core);
-		}
-	}
-
-
-	public class MMnRenderer : ToolStripProfessionalRenderer
-	{
-		public MMnRenderer() : base(new CustomMenuColor()) { }
-
-		protected override void OnRenderMenuItemBackground(ToolStripItemRenderEventArgs e)
-		{
-			Color c = e.Item.Selected ? ColorScheme.MenuHighlightColor : ColorScheme.FormBackColor;
-			e.Graphics.Clear(c);
-		}
-
-		protected override void OnRenderImageMargin(ToolStripRenderEventArgs e)
-		{
-			e.Graphics.Clear(ColorScheme.FormBackColor);
-		}
-
-		protected override void OnRenderItemBackground(ToolStripItemRenderEventArgs e)
-		{
-			e.Graphics.Clear(ColorScheme.FormBackColor);
-		}
-
-		protected override void OnRenderItemText(ToolStripItemTextRenderEventArgs e)
-		{
-			Color c = e.Item.Enabled ? ColorScheme.FormForeColor : Color.Gray;
-			TextRenderer.DrawText(e.Graphics, e.Text, e.TextFont, e.TextRectangle, c, e.TextFormat);
-		}
-
-		protected override void OnRenderToolStripBackground(ToolStripRenderEventArgs e)
-		{
-			e.Graphics.Clear(ColorScheme.FormBackColor);
-		}
-
-		protected override void OnRenderToolStripContentPanelBackground(ToolStripContentPanelRenderEventArgs e)
-		{
-			e.Graphics.Clear(ColorScheme.FormBackColor);
-		}
-
-		protected override void OnRenderToolStripPanelBackground(ToolStripPanelRenderEventArgs e)
-		{
-			e.Graphics.Clear(ColorScheme.FormBackColor);
-		}
-
-		protected override void OnRenderToolStripBorder(ToolStripRenderEventArgs e)
-		{
-			base.OnRenderToolStripBorder(e);
-
-			using (Brush b = new SolidBrush(ColorScheme.FormBackColor))
-				e.Graphics.FillRectangle(b, e.ConnectedArea);
-		}
-	}
-	public class CustomMenuColor : ProfessionalColorTable
-	{
-		public override Color SeparatorDark
-		{ get { return ColorScheme.MenuSeparatorColor; } }
-
-		public override Color SeparatorLight
-		{ get { return ColorScheme.MenuSeparatorColor; } }
-	}
+    public partial class MainForm : Form
+    {
+        private GrblCore Core;
+        private UsageStats.MessageData ToolBarMessage;
+        private bool IsBufferStuck = false;
+        private bool MultiRunShown = false;
+        private bool OrturWiFiShown;
+        private readonly string[] args;
+
+        public MainForm()
+        {
+            InitializeComponent();
+
+            MnOrtur.Visible = false;
+            MMn.Renderer = new MMnRenderer();
+
+
+            splitContainer1.FixedPanel = FixedPanel.Panel1;
+            splitContainer1.SplitterDistance = Settings.GetObject("MainForm Splitter Position", 260);
+
+            MnNotifyNewVersion.Checked = Settings.GetObject("Auto Update", true);
+            MnNotifyMinorVersion.Checked = Settings.GetObject("Auto Update Build", false);
+            MnNotifyPreRelease.Checked = Settings.GetObject("Auto Update Pre", false);
+
+            MnAutoUpdate.DropDown.Closing += MnAutoUpdateDropDown_Closing;
+
+            if (System.Threading.Thread.CurrentThread.Name == null)
+                System.Threading.Thread.CurrentThread.Name = "Main Thread";
+
+            using (SplashScreenForm f = new SplashScreenForm())
+                f.ShowDialog(this);
+
+            //build main communication object
+            Firmware ftype = Settings.GetObject("Firmware Type", Firmware.Grbl);
+            if (ftype == Firmware.Smoothie)
+                Core = new SmoothieCore(this, PreviewForm, JogForm);
+            else if (ftype == Firmware.Marlin)
+                Core = new MarlinCore(this, PreviewForm, JogForm);
+            else if (ftype == Firmware.VigoWork)
+                Core = new VigoCore(this, PreviewForm, JogForm);
+            else
+                Core = new GrblCore(this, PreviewForm, JogForm);
+            ExceptionManager.Core = Core;
+
+            if (true) //use multi instance trigger
+            {
+                SincroStart.StartListen(Core);
+                MultipleInstanceTimer.Enabled = true;
+            }
+
+            MnGrblConfig.Visible = Core.UIShowGrblConfig;
+            MnUnlock.Visible = Core.UIShowUnlockButtons;
+
+            MnGrbl.Text = Core.Type.ToString();
+
+            Core.MachineStatusChanged += OnMachineStatus;
+            Core.OnFileLoaded += OnFileLoaded;
+            Core.OnOverrideChange += RefreshOverride;
+            Core.IssueDetected += OnIssueDetected;
+
+            PreviewForm.SetCore(Core);
+            ConnectionForm.SetCore(Core);
+            JogForm.SetCore(Core);
+
+            GitHub.NewVersion += GitHub_NewVersion;
+
+            ColorScheme.CurrentScheme = Settings.GetObject("Color Schema", ColorScheme.Scheme.BlueLaser); ;
+            RefreshColorSchema(); //include RefreshOverride();
+            RefreshFormTitle();
+        }
+
+        public MainForm(string[] args) : this()
+        {
+            this.args = args;
+        }
+
+        private void MnAutoUpdateDropDown_Closing(object sender, ToolStripDropDownClosingEventArgs e)
+        {
+            if (e.CloseReason == ToolStripDropDownCloseReason.ItemClicked)
+            {
+                e.Cancel = true;
+            }
+        }
+
+        void OnIssueDetected(GrblCore.DetectedIssue issue)
+        {
+            if (!Settings.GetObject("Do not show Issue Detector", false))
+                IssueDetectorForm.CreateAndShowDialog(this, issue);
+        }
+
+        private void RefreshColorSchema()
+        {
+            MMn.BackColor = BackColor = StatusBar.BackColor = ColorScheme.FormBackColor;
+            MMn.ForeColor = ForeColor = ColorScheme.FormForeColor;
+            blueLaserToolStripMenuItem.Checked = ColorScheme.CurrentScheme == ColorScheme.Scheme.BlueLaser;
+            redLaserToolStripMenuItem.Checked = ColorScheme.CurrentScheme == ColorScheme.Scheme.RedLaser;
+            darkToolStripMenuItem.Checked = ColorScheme.CurrentScheme == ColorScheme.Scheme.Dark;
+            hackerToolStripMenuItem.Checked = ColorScheme.CurrentScheme == ColorScheme.Scheme.Hacker;
+            nightyToolStripMenuItem.Checked = ColorScheme.CurrentScheme == ColorScheme.Scheme.Nighty;
+            TTLinkToNews.LinkColor = ColorScheme.LinkColor;
+            TTLinkToNews.VisitedLinkColor = ColorScheme.VisitedLinkColor;
+            ConnectionForm.OnColorChange();
+            PreviewForm.OnColorChange();
+            RefreshOverride();
+        }
+
+        void GitHub_NewVersion(Version current, GitHub.OnlineVersion available, Exception error)
+        {
+            if (InvokeRequired)
+            {
+                Invoke(new GitHub.NewVersionDlg(GitHub_NewVersion), current, available, error);
+            }
+            else
+            {
+                if (error != null)
+                    MessageBox.Show(this, "Cannot check for new version, please verify http://lasergrbl.com manually.", "Software info", MessageBoxButtons.OK, MessageBoxIcon.Error, MessageBoxDefaultButton.Button1);
+                else if (available != null)
+                    NewVersionForm.CreateAndShowDialog(current, available, this);
+                else
+                    MessageBox.Show(this, "You have the most updated version!", "Software info", MessageBoxButtons.OK, MessageBoxIcon.Information, MessageBoxDefaultButton.Button1);
+
+            }
+        }
+
+        private void MainForm_Load(object sender, EventArgs e)
+        {
+            bool canrun = Settings.GetObject("IsDisclamerAccepted", false);
+            if (!canrun)
+            {
+                using (LegalDisclaimer lds = new LegalDisclaimer())
+                {
+                    lds.ShowDialog();
+                    if (lds.accepted)
+                    {
+                        canrun = true;
+                        Settings.SetObject("IsDisclamerAccepted", true);
+                    }
+                }
+            }
+
+            if (canrun)
+            {
+                UpdateTimer.Enabled = true;
+
+                if (Settings.GetObject("Auto Update", true))
+                    GitHub.CheckVersion(false);
+
+                SuspendLayout();
+                //restore last size and position
+                Object[] msp = Settings.GetObject<Object[]>("Mainform Size and Position", null);
+                FormWindowState state = msp == null ? FormWindowState.Maximized : (FormWindowState)msp[2] != FormWindowState.Minimized ? (FormWindowState)msp[2] : FormWindowState.Maximized;
+                if (state == FormWindowState.Normal)
+                { WindowState = state; Size = (Size)msp[0]; Location = (Point)msp[1]; }
+                ResumeLayout();
+
+                ManageMessage();
+                ManageCommandLineArgs(args);
+            }
+            else
+            {
+                Close();
+            }
+        }
+
+        private void ManageCommandLineArgs(string[] args)
+        {
+            if (args != null && args.Length == 1)
+            {
+                string filename = args[0];
+                if (System.IO.File.Exists(filename))
+                {
+                    Application.DoEvents();
+
+                    if (System.IO.Path.GetExtension(filename).ToLower() == ".zbn") //zipped button
+                    {
+                        PreviewForm.ImportButton(filename);
+                    }
+                    else
+                    {
+                        if (Core.CanLoadNewFile)
+                            Core.OpenFile(this, filename, false);
+                        else
+                            MessageBox.Show(Strings.MsgboxCannotOpenFileNow);
+                    }
+                }
+            }
+        }
+
+        private void ManageMessage()
+        {
+            try
+            {
+                foreach (UsageStats.MessageData M in UsageStats.Messages.GetMessages(UsageStats.MessageData.MessageTypes.AutoLink))
+                {
+                    Tools.Utils.OpenLink(M.Content);
+                    UsageStats.Messages.ClearMessage(M);
+                }
+
+                ToolBarMessage = UsageStats.Messages.GetMessage(UsageStats.MessageData.MessageTypes.ToolbarLink);
+                if (ToolBarMessage != null && ToolBarMessage.Title != null && ToolBarMessage.Content != null)
+                {
+                    TTLinkToNews.Text = ToolBarMessage.Title;
+                    TTLinkToNews.Enabled = true;
+
+                    this.TTLinkToNews.LinkBehavior = System.Windows.Forms.LinkBehavior.HoverUnderline;
+                }
+            }
+            catch (Exception ex) { System.Diagnostics.Debug.WriteLine(ex); }
+        }
+
+        void OnFileLoaded(long elapsed, string filename)
+        {
+            if (InvokeRequired)
+            {
+                Invoke(new GrblFile.OnFileLoadedDlg(OnFileLoaded), elapsed, filename);
+            }
+            else
+            {
+                TimerUpdate();
+                //TTTFile.Text = System.IO.Path.GetFileName(filename);
+                TTTLines.Text = Core.LoadedFile.Count.ToString();
+                //TTTLoadedIn.Text = elapsed.ToString() + " ms";
+                TTTEstimated.Text = Tools.Utils.TimeSpanToString(Core.LoadedFile.EstimatedTime, Tools.Utils.TimePrecision.Second, Tools.Utils.TimePrecision.Second, " ,", true);
+            }
+        }
+
+
+        bool PrevConnected = false;
+        void OnMachineStatus()
+        {
+            TimerUpdate();
+
+            if (Core.MachineStatus == GrblCore.MacStatus.Disconnected && Core.FailedConnectionCount >= 3)
+            {
+                string url = null;
+                ComWrapper.WrapperType wt = Settings.GetObject("ComWrapper Protocol", ComWrapper.WrapperType.UsbSerial);
+
+                if (wt == ComWrapper.WrapperType.UsbSerial || wt == ComWrapper.WrapperType.UsbSerial2)
+                    url = "https://lasergrbl.com/usage/arduino-connection/";
+                else if (wt == ComWrapper.WrapperType.Telnet || wt == ComWrapper.WrapperType.LaserWebESP8266)
+                    url = "https://lasergrbl.com/usage/wifi-with-esp8266/";
+
+                if (url != null)
+                    MessageBox.Show(this, Strings.ProblemConnectingText, Strings.ProblemConnectingTitle, MessageBoxButtons.OK, MessageBoxIcon.Information, MessageBoxDefaultButton.Button1, 0, url);
+            }
+
+            if (Core.IsConnected && !PrevConnected)
+            {
+                LaserLifeHandler.OnConnect(this);
+            }
+            if (!Core.IsConnected && PrevConnected)
+            {
+                LaserLifeHandler.OnDisconnect();
+            }
+
+            PrevConnected = Core.IsConnected;
+
+        }
+        void MainFormFormClosing(object sender, FormClosingEventArgs e)
+        {
+            if (Core.InProgram && System.Windows.Forms.MessageBox.Show(Strings.ExitAnyway, Strings.WarnMessageBoxHeader, MessageBoxButtons.YesNo, MessageBoxIcon.Warning, MessageBoxDefaultButton.Button2) != System.Windows.Forms.DialogResult.Yes)
+                e.Cancel = true;
+
+            if (!e.Cancel)
+            {
+                SincroStart.StopListen();
+                Core.Exiting();
+                Settings.SetObject("Mainform Size and Position", new object[] { Size, Location, WindowState });
+                Settings.Exiting();
+
+                UsageStats.SaveFile(Core);
+            }
+        }
+
+
+        private void UpdateTimer_Tick(object sender, EventArgs e)
+        {
+            long foo = HiResTimer.TotalNano; //ensure call TotalNano to be able to detect and fix sleep/hibernation
+            TimerUpdate();
+            ConnectionForm.TimerUpdate();
+            PreviewForm.TimerUpdate();
+            JogForm.Enabled = Core.JogEnabled;
+            PromptOrturWiFi();
+        }
+
+        private void PromptOrturWiFi()
+        {
+            if (!OrturWiFiShown && !Settings.GetObject("Suppress Ortur WiFI Message", false) && Core.GrblVersion != null && Core.GrblVersion.IsLuckyOrturWiFi && !IsConfiguredForWiFi() && Core.CanReadWriteConfig)
+            {
+                OrturWiFiShown = true;
+
+                using (OrturWiFiConfigPrompt F = new OrturWiFiConfigPrompt(Core))
+                {
+                    if (F.ShowDialog(this) == DialogResult.OK)
+                        ShowWiFiConfig();
+                }
+
+            }
+        }
+
+        private void ShowWiFiConfig()
+        {
+            using (OrturWiFiConfig F2 = new OrturWiFiConfig(Core))
+            {
+                if (F2.ShowDialog(this) == DialogResult.OK && Core.DetectedIP != null)
+                {
+                    ConnectionForm.ConfigFromOrtur($"{Core.DetectedIP}:{GrblCore.Configuration.TelnetPort}");
+                    Settings.SetObject("ComWrapper Protocol", ComWrapper.WrapperType.Telnet);
+                    Core.CloseCom(true);
+                }
+
+            }
+        }
+
+        private void TimerUpdate()
+        {
+            SuspendLayout();
+            TTTStatus.Text = GrblCore.TranslateEnum(Core.MachineStatus);
+
+            if (Core.InProgram)
+                TTTEstimated.Text = Tools.Utils.TimeSpanToString(Core.ProjectedTime, Tools.Utils.TimePrecision.Second, Tools.Utils.TimePrecision.Second, " ,", true);
+            else
+                TTTEstimated.Text = Tools.Utils.TimeSpanToString(Core.LoadedFile.EstimatedTime, Tools.Utils.TimePrecision.Second, Tools.Utils.TimePrecision.Second, " ,", true);
+
+            if (Core.InProgram)
+                TTLEstimated.Text = Strings.MainFormProjectedTime;
+            else
+                TTLEstimated.Text = Strings.MainFormEstimatedTime;
+
+            MnFileOpen.Enabled = Core.CanLoadNewFile;
+            MnSaveProject.Enabled = MnAdvancedSave.Enabled = MnSaveProgram.Enabled = Core.HasProgram;
+            MnFileSend.Enabled = Core.CanSendFile;
+            MnStartFromPosition.Enabled = Core.CanSendFile;
+            MnRunMulti.Enabled = Core.CanSendFile || Core.CanResumeHold || Core.CanFeedHold;
+            MnGrblConfig.Enabled = true;
+            //MnExportConfig.Enabled = Core.CanImportExport;
+            //MnImportConfig.Enabled = Core.CanImportExport;
+            MnGrblReset.Enabled = Core.CanResetGrbl;
+
+            MNEsp8266.Visible = false;// (Settings.GetObject("ComWrapper Protocol", ComWrapper.WrapperType.UsBSerial)) == ComWrapper.WrapperType.LaserWebESP8266;
+
+            MnConnect.Visible = !Core.IsConnected;
+            MnDisconnect.Visible = Core.IsConnected;
+
+            MnGoHome.Visible = GrblCore.Configuration.HomingEnabled;
+            MnGoHome.Enabled = Core.CanDoHoming;
+            MnUnlock.Enabled = Core.CanUnlock;
+
+            TTOvG0.Visible = Core.SupportOverride;
+            TTOvG1.Visible = Core.SupportOverride;
+            TTOvS.Visible = Core.SupportOverride;
+            spacer.Visible = Core.SupportOverride;
+
+            MnWiFiDiscovery.Visible = IsConfiguredForWiFi();
+            MnWiFiDiscovery.Enabled = !Core.IsConnected;
+
+            ComWrapper.WrapperType wr = Settings.GetObject("ComWrapper Protocol", ComWrapper.WrapperType.UsbSerial);
+
+            MnSeparatorConfigWiFi.Visible = MnConfigureOrturWiFi.Visible = Core.GrblVersion != null && (wr == ComWrapper.WrapperType.UsbSerial || wr == ComWrapper.WrapperType.UsbSerial2) && Core.GrblVersion.IsLuckyOrturWiFi;
+            MnConfigureOrturWiFi.Enabled = MnConfigureOrturWiFi.Visible && Core.CanReadWriteConfig;
+
+            switch (Core.MachineStatus)
+            {
+                //Disconnected, Connecting, Idle, *Run, *Hold, *Door, Home, *Alarm, *Check, *Jog
+
+                case GrblCore.MacStatus.Alarm:
+                    TTTStatus.BackColor = Color.Red;
+                    TTTStatus.ForeColor = Color.White;
+                    break;
+                case GrblCore.MacStatus.Door:
+                case GrblCore.MacStatus.Hold:
+                case GrblCore.MacStatus.Cooling:
+                case GrblCore.MacStatus.AutoHold:
+                    TTTStatus.BackColor = Color.DarkOrange;
+                    TTTStatus.ForeColor = Color.Black;
+                    break;
+                case GrblCore.MacStatus.Jog:
+                case GrblCore.MacStatus.Run:
+                case GrblCore.MacStatus.Check:
+                    TTTStatus.BackColor = Color.LightGreen;
+                    TTTStatus.ForeColor = Color.Black;
+                    break;
+                default:
+                    TTTStatus.BackColor = ColorScheme.FormBackColor;
+                    TTTStatus.ForeColor = ColorScheme.FormForeColor;
+                    break;
+            }
+
+            PbBuffer.Maximum = Core.BufferSize;
+            PbBuffer.Value = Core.UsedBuffer;
+            PbBuffer.ToolTipText = $"Buffer: {Core.UsedBuffer}/{Core.BufferSize} Free:{Core.FreeBuffer}";
+
+            bool stuck = Core.IsBufferStuck();
+            if (stuck != IsBufferStuck)
+            {
+                IsBufferStuck = stuck;
+                PbBuffer.ProgressBar.SetState(stuck ? 2 : 1);
+                BtnUnlockFromStuck.Enabled = stuck;
+            }
+
+            MnOrtur.Visible = Core.IsOrturBoard;
+
+            string NewTTLLText = $"{LaserLifeHandler.GetCurrentTime().TotalHours.ToString("0.0", System.Globalization.CultureInfo.InvariantCulture)}h";
+            if (TTlaserLife.Text != NewTTLLText) TTlaserLife.Text = NewTTLLText; //prevent tooltip flickering
+
+            ResumeLayout();
+        }
+
+        private bool IsConfiguredForWiFi()
+        {
+            ComWrapper.WrapperType wt = Settings.GetObject("ComWrapper Protocol", ComWrapper.WrapperType.UsbSerial);
+            return (wt == ComWrapper.WrapperType.LaserWebESP8266 || wt == ComWrapper.WrapperType.Telnet);
+        }
+
+        private void RefreshFormTitle()
+        {
+            string FormTitle = string.Format("LaserGRBL v{0}", Program.CurrentVersion.ToString(3));
+
+            if (Core.Type != Firmware.Grbl)
+                FormTitle = FormTitle + $" (for {Core.Type})";
+
+
+            if (Text != FormTitle) Text = FormTitle;
+        }
+
+        void ExitToolStripMenuItemClick(object sender, EventArgs e)
+        {
+            Close();
+        }
+
+        private void MnFileOpen_Click(object sender, EventArgs e)
+        {
+            Project.ClearSettings();
+            Core.OpenFile(this);
+        }
+
+        private void MnFileSend_Click(object sender, EventArgs e)
+        {
+            Core.RunProgram(this);
+        }
+
+        private void MnGrblReset_Click(object sender, EventArgs e)
+        {
+            Core.GrblReset();
+        }
+
+        void RefreshOverride()
+        {
+            SuspendLayout();
+            TTOvG0.Text = string.Format("G0 [{0:0.00}x]", Core.OverrideG0 / 100.0);
+            TTOvG0.BackColor = Core.OverrideG0 > 100 ? Color.LightPink : (Core.OverrideG0 < 100 ? Color.LightBlue : ColorScheme.FormBackColor);
+            TTOvG0.ForeColor = Core.OverrideG0 != 100 ? Color.Black : ColorScheme.FormForeColor;
+            TTOvG1.Text = string.Format("G1 [{0:0.00}x]", Core.OverrideG1 / 100.0);
+            TTOvG1.BackColor = Core.OverrideG1 > 100 ? Color.LightPink : (Core.OverrideG1 < 100 ? Color.LightBlue : ColorScheme.FormBackColor);
+            TTOvG1.ForeColor = Core.OverrideG1 != 100 ? Color.Black : ColorScheme.FormForeColor;
+            TTOvS.Text = string.Format("S [{0:0.00}x]", Core.OverrideS / 100.0);
+            TTOvS.BackColor = Core.OverrideS > 100 ? Color.LightPink : (Core.OverrideS < 100 ? Color.LightBlue : ColorScheme.FormBackColor);
+            TTOvS.ForeColor = Core.OverrideS != 100 ? Color.Black : ColorScheme.FormForeColor;
+
+            ResumeLayout();
+        }
+        void TTOvClick(object sender, EventArgs e)
+        {
+            GetOvMenu().Show(Cursor.Position, ToolStripDropDownDirection.AboveLeft);
+        }
+
+
+
+        internal virtual System.Windows.Forms.ContextMenuStrip GetOvMenu()
+        {
+            System.Windows.Forms.ContextMenuStrip CM = new System.Windows.Forms.ContextMenuStrip();
+            CM.Items.Add(new ToolStripTraceBarItem(Core, 2));
+            CM.Items.Add(new ToolStripTraceBarItem(Core, 1));
+            CM.Items.Add(new ToolStripTraceBarItem(Core, 0));
+            CM.Width = 150;
+
+            return CM;
+        }
+
+        /// <summary>
+        /// Adds trackbar to toolstrip stuff
+        /// </summary>
+        [System.Windows.Forms.Design.ToolStripItemDesignerAvailability(System.Windows.Forms.Design.ToolStripItemDesignerAvailability.ToolStrip | System.Windows.Forms.Design.ToolStripItemDesignerAvailability.StatusStrip)]
+        public class ToolStripTraceBarItem : System.Windows.Forms.ToolStripControlHost
+        {
+            public ToolStripTraceBarItem(GrblCore core, int function)
+                : base(new UserControls.LabelTB(core, function))
+            {
+                Control.Dock = System.Windows.Forms.DockStyle.Fill;
+            }
+        }
+
+        private void MnGoHome_Click(object sender, EventArgs e)
+        {
+            Core.SendHomingCommand();
+        }
+
+        private void MnUnlock_Click(object sender, EventArgs e)
+        {
+            Core.SendUnlockCommand();
+        }
+
+        private void MnConnect_Click(object sender, EventArgs e)
+        {
+            Core.OpenCom();
+        }
+
+        private void MnDisconnect_Click(object sender, EventArgs e)
+        {
+            if (!(Core.InProgram && System.Windows.Forms.MessageBox.Show(Strings.DisconnectAnyway, Strings.WarnMessageBoxHeader, MessageBoxButtons.YesNo, MessageBoxIcon.Warning, MessageBoxDefaultButton.Button2) != System.Windows.Forms.DialogResult.Yes))
+                Core.CloseCom(true);
+        }
+        void MnSaveProgramClick(object sender, EventArgs e)
+        {
+            Core.SaveProgram(this, false, false, false, 1, false);
+        }
+
+        private void MnAdvancedSave_Click(object sender, EventArgs e)
+        {
+            SaveOptionForm.CreateAndShowDialog(this, Core);
+        }
+
+        private void MnSaveProject_Click(object sender, EventArgs e)
+        {
+            Core.SaveProject(this);
+        }
+
+        private void MNEnglish_Click(object sender, EventArgs e)
+        {
+            SetLanguage(new System.Globalization.CultureInfo("en"));
+        }
+
+        private void MNItalian_Click(object sender, EventArgs e)
+        {
+            SetLanguage(new System.Globalization.CultureInfo("it"));
+        }
+
+        private void MNSpanish_Click(object sender, EventArgs e)
+        {
+            SetLanguage(new System.Globalization.CultureInfo("es"));
+        }
+
+        private void SetLanguage(System.Globalization.CultureInfo ci)
+        {
+            if (ci != null)
+                Settings.SetObject("User Language", ci);
+            else
+                Settings.DeleteObject("User Language");
+
+            if (MessageBox.Show(Strings.LanguageRequireRestartNow, Strings.LanguageRequireRestart, MessageBoxButtons.OKCancel) == DialogResult.OK)
+                Application.Restart();
+        }
+
+        private void helpOnLineToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            Core.HelpOnLine();
+        }
+
+        private void aboutToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            Tools.Utils.OpenLink(@"https://lasergrbl.com/faq/");
+        }
+
+        private void splitContainer1_SplitterMoved(object sender, SplitterEventArgs e)
+        {
+            Settings.SetObject("MainForm Splitter Position", splitContainer1.SplitterDistance);
+        }
+
+        private void settingsToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            SettingsForm.CreateAndShowDialog(this, Core);
+        }
+
+        private void openSessionLogToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            if (Logger.ExistLog)
+                Logger.ShowLog();
+        }
+
+        private void toolStripMenuItem4_DropDownOpening(object sender, EventArgs e)
+        {
+            openSessionLogToolStripMenuItem.Enabled = Logger.ExistLog;
+            activateExtendedLogToolStripMenuItem.Checked = ComWrapper.ComLogger.Enabled;
+        }
+
+        private void MNFrench_Click(object sender, EventArgs e)
+        {
+            SetLanguage(new System.Globalization.CultureInfo("fr"));
+        }
+
+        private void MNGerman_Click(object sender, EventArgs e)
+        {
+            SetLanguage(new System.Globalization.CultureInfo("de"));
+        }
+
+        private void MNDanish_Click(object sender, EventArgs e)
+        {
+            SetLanguage(new System.Globalization.CultureInfo("da"));
+        }
+
+        private void MNBrazilian_Click(object sender, EventArgs e)
+        {
+            SetLanguage(new System.Globalization.CultureInfo("pt-BR"));
+        }
+
+        private void russianToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            SetLanguage(new System.Globalization.CultureInfo("ru"));
+        }
+
+        private void chineseToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            SetLanguage(new System.Globalization.CultureInfo("zh-CN"));
+        }
+
+        private void slovakToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            SetLanguage(new System.Globalization.CultureInfo("sk-SK"));
+        }
+
+        private void MNGrblEmulator_Click(object sender, EventArgs e)
+        {
+            GrblEmulator.WebSocketEmulator.Start();
+        }
+
+        private void blueLaserToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            SetSchema(ColorScheme.Scheme.BlueLaser);
+        }
+
+        private void redLaserToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            SetSchema(ColorScheme.Scheme.RedLaser);
+        }
+
+        private void darkToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            SetSchema(ColorScheme.Scheme.Dark);
+        }
+
+        private void hackerToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            SetSchema(ColorScheme.Scheme.Hacker);
+        }
+
+        private void nightyToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            SetSchema(ColorScheme.Scheme.Nighty);
+        }
+
+        private void SetSchema(ColorScheme.Scheme schema)
+        {
+            Settings.SetObject("Color Schema", schema);
+            ColorScheme.CurrentScheme = schema;
+            RefreshColorSchema();
+        }
+
+        private void grblConfigurationToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            GrblConfig.CreateAndShowDialog(this, Core);
+        }
+
+        private void donateToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            Tools.Utils.OpenLink(@"https://lasergrbl.com/donate");
+        }
+
+        protected override void OnKeyUp(KeyEventArgs e)
+        {
+            mLastkeyData = Keys.None;
+            Core.ManageHotKeys(this, Keys.None);
+            base.OnKeyUp(e);
+        }
+
+        Keys mLastkeyData = Keys.None;
+        protected override bool ProcessCmdKey(ref Message msg, Keys keyData)
+        {
+            if (keyData != mLastkeyData)
+            {
+                mLastkeyData = keyData;
+                return Core.ManageHotKeys(this, keyData);
+            }
+
+            return base.ProcessCmdKey(ref msg, keyData);
+        }
+
+        private void MnReOpenFile_Click(object sender, EventArgs e)
+        {
+            Project.ClearSettings();
+            Core.ReOpenFile(this);
+        }
+
+        private void fileToolStripMenuItem_DropDownOpening(object sender, EventArgs e)
+        {
+            MnReOpenFile.Enabled = Core.CanReOpenFile;
+        }
+
+        private void MnHotkeys_Click(object sender, EventArgs e)
+        {
+            HotkeyManagerForm.CreateAndShowDialog(this, Core);
+        }
+
+
+        private void AwakeTimer_Tick(object sender, EventArgs e)
+        {
+            if (Core != null && Core.InProgram)
+                Tools.WinAPI.SignalActvity();
+        }
+
+        private void MnStartFromPosition_Click(object sender, EventArgs e)
+        {
+            Core.RunProgramFromPosition(this);
+        }
+
+        private void MnFileAppend_Click(object sender, EventArgs e)
+        {
+            Core.OpenFile(this, null, true);
+        }
+
+        private void hungarianToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            SetLanguage(new System.Globalization.CultureInfo("hu-HU"));
+        }
+
+        private void czechToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            SetLanguage(new System.Globalization.CultureInfo("cs-CZ"));
+        }
+
+        private void installCH340DriverToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            try
+            {
+                string fname = System.IO.Path.Combine(GrblCore.ExePath, "Driver\\CH341SER.EXE");
+                System.Diagnostics.Process.Start(fname);
+            }
+            catch { Tools.Utils.OpenLink("https://www.google.it/search?q=ch340+drivers"); }
+        }
+
+        private void flashGrblFirmwareToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            FlashGrbl form = new FlashGrbl();
+            form.ShowDialog(this);
+            if (form.retval != int.MinValue)
+            {
+                if (form.retval == 0)
+                    MessageBox.Show("Firmware flashed succesfull!", "Result", MessageBoxButtons.OK, MessageBoxIcon.Information);
+                else
+                    MessageBox.Show("Error: cannot flash firmware.", "Result", MessageBoxButtons.OK, MessageBoxIcon.Error);
+            }
+
+            form.Dispose();
+
+        }
+
+        private void toolsToolStripMenuItem_DropDownOpening(object sender, EventArgs e)
+        {
+            flashGrblFirmwareToolStripMenuItem.Enabled = (Core.MachineStatus == GrblCore.MacStatus.Disconnected);
+        }
+
+        private void activateExtendedLogToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            if (!ComWrapper.ComLogger.Enabled)
+            {
+                using (SaveFileDialog sfd = new System.Windows.Forms.SaveFileDialog())
+                {
+                    sfd.InitialDirectory = Environment.GetFolderPath(Environment.SpecialFolder.Desktop);
+                    sfd.Filter = "Communication log|*.txt";
+                    sfd.AddExtension = true;
+                    sfd.OverwritePrompt = false;
+                    sfd.FileName = "comlog.txt";
+                    sfd.Title = "Select extended log filename";
+
+                    DialogResult dialogResult = DialogResult.Cancel;
+                    try
+                    {
+                        dialogResult = sfd.ShowDialog(this);
+                    }
+                    catch (System.Runtime.InteropServices.COMException)
+                    {
+                        sfd.AutoUpgradeEnabled = false;
+                        dialogResult = sfd.ShowDialog(this);
+                    }
+
+                    if (dialogResult == DialogResult.OK && sfd.FileName != null)
+                    {
+                        string message = ComWrapper.ComLogger.StartLog(sfd.FileName);
+                        Logger.LogMessage("ComLog", message);
+                    }
+                }
+            }
+            else
+            {
+                string message = ComWrapper.ComLogger.StopLog();
+                if (message != null) Logger.LogMessage("ComLog", message);
+            }
+        }
+
+        private DispatcherTimer dropDispatcherTimer;
+        private string droppedFile;
+
+        private void MainForm_DragEnter(object sender, DragEventArgs e)
+        {
+            if (droppedFile == null)
+            {
+                if (e.Data.GetDataPresent(DataFormats.FileDrop)) e.Effect = DragDropEffects.Copy;
+            }
+        }
+
+        private void MainForm_DragDrop(object sender, DragEventArgs e)
+        {
+            if (droppedFile == null)
+            {
+                string[] files = (string[])e.Data.GetData(DataFormats.FileDrop);
+                if (files.Length == 1)
+                {
+                    droppedFile = files[0];
+
+                    // call via DispatcherTimer to unblock the source of the drag-event (e.g. Explorer-Window)
+                    if (dropDispatcherTimer == null)
+                    {
+                        this.dropDispatcherTimer = new DispatcherTimer();
+                        this.dropDispatcherTimer.Interval = TimeSpan.FromSeconds(0.5);
+                        this.dropDispatcherTimer.Tick += new EventHandler(dropDispatcherTimer_Tick);
+                    }
+                    this.dropDispatcherTimer.Start();
+                }
+            }
+        }
+
+        void dropDispatcherTimer_Tick(object sender, EventArgs e)
+        {
+            if (this.droppedFile != null)
+            {
+                Core.OpenFile(this, this.droppedFile);
+                this.droppedFile = null;
+                dropDispatcherTimer.Stop();
+            }
+        }
+
+        private void licenseToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            LicenseForm.CreateAndShowDialog(this);
+        }
+
+        private void MnNotifyNewVersion_Click(object sender, EventArgs e)
+        {
+            MnNotifyNewVersion.Checked = !MnNotifyNewVersion.Checked;
+            Settings.SetObject("Auto Update", MnNotifyNewVersion.Checked);
+
+            //if (MnNotifyNewVersion.Checked)
+            //	GitHub.CheckVersion();
+        }
+
+        private void MnNotifyNewVersion_CheckedChanged(object sender, EventArgs e)
+        {
+            if (!MnNotifyNewVersion.Checked) //disabilita il minor update
+            {
+                MnNotifyMinorVersion.Enabled = false;
+                MnNotifyMinorVersion.Checked = false;
+                MnNotifyPreRelease.Enabled = false;
+                MnNotifyPreRelease.Checked = false;
+                Settings.SetObject("Auto Update Build", false);
+                Settings.SetObject("Auto Update Pre", false);
+            }
+            else
+            {
+                MnNotifyMinorVersion.Enabled = true;
+                MnNotifyMinorVersion.Checked = Settings.GetObject("Auto Update Build", false);
+                MnNotifyPreRelease.Enabled = true;
+                MnNotifyPreRelease.Checked = Settings.GetObject("Auto Update Pre", false);
+            }
+        }
+
+        private void MnNotifyMinorVersion_Click(object sender, EventArgs e)
+        {
+            MnNotifyMinorVersion.Checked = !MnNotifyMinorVersion.Checked;
+            Settings.SetObject("Auto Update Build", MnNotifyMinorVersion.Checked);
+
+            //if (MnNotifyNewVersion.Checked && MnNotifyMinorVersion.Checked)
+            //	GitHub.CheckVersion();
+        }
+
+        private void MnNotifyPreRelease_Click(object sender, EventArgs e)
+        {
+            MnNotifyPreRelease.Checked = !MnNotifyPreRelease.Checked;
+            Settings.SetObject("Auto Update Pre", MnNotifyPreRelease.Checked);
+
+            //if (MnNotifyNewVersion.Checked && MnNotifyPreRelease.Checked)
+            //	GitHub.CheckVersion();
+        }
+
+        private void MnCheckNow_Click(object sender, EventArgs e)
+        {
+            questionMarkToolStripMenuItem.HideDropDown();
+            GitHub.CheckVersion(true);
+        }
+
+        private void MnMaterialDB_Click(object sender, EventArgs e)
+        {
+            PSHelper.PSEditorForm.CreateAndShowDialog(this);
+        }
+
+        private void polishToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            SetLanguage(new System.Globalization.CultureInfo("pl-PL"));
+        }
+
+        private void orturSupportGroupToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            Tools.Utils.OpenLink(@"https://lasergrbl.com/orturfacebook/");
+        }
+
+        private void orturWebsiteToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            Tools.Utils.OpenLink(@"https://lasergrbl.com/orturwebsite/");
+        }
+
+        private void traditionalChineseToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            SetLanguage(new System.Globalization.CultureInfo("zh-TW"));
+        }
+
+        private void youtubeChannelToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            Tools.Utils.OpenLink(@"https://lasergrbl.com/orturYTchannel/");
+        }
+
+        private void firmwareToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            Tools.Utils.OpenLink(@"https://lasergrbl.com/ortur-firmware/");
+        }
+
+        private void manualsDownloadToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            Tools.Utils.OpenLink(@"https://lasergrbl.com/ortur-manuals/");
+        }
+
+        private void MultipleInstanceTimer_Tick(object sender, EventArgs e)
+        {
+            MultipleInstanceTimer.Interval = 5000;
+            MnRunMulti.Visible = MnRunMultiSep.Visible = SincroStart.Running() && System.Diagnostics.Process.GetProcessesByName(System.IO.Path.GetFileNameWithoutExtension(System.Reflection.Assembly.GetEntryAssembly().Location)).Length > 1;
+        }
+
+        private void MnRunMulti_Click(object sender, EventArgs e)
+        {
+            if (MultiRunShown || MessageBox.Show(this, "Warning: this command will start/resume all job in any running LaserGRBL instance!", "Warning", MessageBoxButtons.OKCancel, MessageBoxIcon.Warning) == DialogResult.OK)
+            {
+                SincroStart.Signal();
+                MultiRunShown = true;
+            }
+        }
+
+        private void orturSupportAndFeedbackToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            Tools.Utils.OpenLink(@"https://lasergrbl.com/ortursupport/");
+        }
+
+        private void TTLinkToNews_Click(object sender, EventArgs e)
+        {
+            if (ToolBarMessage != null && ToolBarMessage.Title != null && ToolBarMessage.Content != null)
+            {
+                Tools.Utils.OpenLink(ToolBarMessage.Content);
+                UsageStats.Messages.ClearMessage(ToolBarMessage);
+            }
+        }
+
+        private void MnWiFiDiscovery_Click(object sender, EventArgs e)
+        {
+            ConnectionForm.ConfigFromDiscovery(WiFiDiscovery.DiscoveryForm.CreateAndShowDialog(this));
+        }
+
+        private void facebookCommunityToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            Tools.Utils.OpenLink(@"https://www.facebook.com/groups/486886768471991");
+        }
+
+        private void greekToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            SetLanguage(new System.Globalization.CultureInfo("el-GR"));
+        }
+
+        private void turkishToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            SetLanguage(new System.Globalization.CultureInfo("tr-TR"));
+        }
+
+        private void BtnUnlockFromStuck_Click(object sender, EventArgs e)
+        {
+            if (MessageBox.Show(Strings.WarnBufferStuckUnlockText, Strings.WarnBufferStuckUnlockTitle, MessageBoxButtons.OKCancel, MessageBoxIcon.Information, MessageBoxDefaultButton.Button1, 0, "http://lasergrbl.com/faq", "issues") == DialogResult.OK)
+            {
+                Core.UnlockFromBufferStuck(false);
+            }
+        }
+
+        private void romanianToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            SetLanguage(new System.Globalization.CultureInfo("ro-RO"));
+        }
+
+        private void dutchToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            SetLanguage(new System.Globalization.CultureInfo("nl-NL"));
+        }
+
+        private void ukrainianToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            SetLanguage(new System.Globalization.CultureInfo("uk"));
+        }
+
+        private void TTTStatus_DoubleClick(object sender, EventArgs e)
+        {
+            Tools.Utils.OpenLink(@"https://lasergrbl.com/usage/machine-status/");
+        }
+
+        private void MnConfigureOrturWiFi_Click(object sender, EventArgs e)
+        {
+            ShowWiFiConfig();
+        }
+
+        private void TTlaserLife_Click(object sender, EventArgs e)
+        {
+            LaserUsage.CreateAndShowDialog(this, Core);
+        }
+
+        private void laserUsageStatsToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            LaserUsage.CreateAndShowDialog(this, Core);
+        }
+    }
+
+
+    public class MMnRenderer : ToolStripProfessionalRenderer
+    {
+        public MMnRenderer() : base(new CustomMenuColor()) { }
+
+        protected override void OnRenderMenuItemBackground(ToolStripItemRenderEventArgs e)
+        {
+            Color c = e.Item.Selected ? ColorScheme.MenuHighlightColor : ColorScheme.FormBackColor;
+            e.Graphics.Clear(c);
+        }
+
+        protected override void OnRenderImageMargin(ToolStripRenderEventArgs e)
+        {
+            e.Graphics.Clear(ColorScheme.FormBackColor);
+        }
+
+        protected override void OnRenderItemBackground(ToolStripItemRenderEventArgs e)
+        {
+            e.Graphics.Clear(ColorScheme.FormBackColor);
+        }
+
+        protected override void OnRenderItemText(ToolStripItemTextRenderEventArgs e)
+        {
+            Color c = e.Item.Enabled ? ColorScheme.FormForeColor : Color.Gray;
+            TextRenderer.DrawText(e.Graphics, e.Text, e.TextFont, e.TextRectangle, c, e.TextFormat);
+        }
+
+        protected override void OnRenderToolStripBackground(ToolStripRenderEventArgs e)
+        {
+            e.Graphics.Clear(ColorScheme.FormBackColor);
+        }
+
+        protected override void OnRenderToolStripContentPanelBackground(ToolStripContentPanelRenderEventArgs e)
+        {
+            e.Graphics.Clear(ColorScheme.FormBackColor);
+        }
+
+        protected override void OnRenderToolStripPanelBackground(ToolStripPanelRenderEventArgs e)
+        {
+            e.Graphics.Clear(ColorScheme.FormBackColor);
+        }
+
+        protected override void OnRenderToolStripBorder(ToolStripRenderEventArgs e)
+        {
+            base.OnRenderToolStripBorder(e);
+
+            using (Brush b = new SolidBrush(ColorScheme.FormBackColor))
+                e.Graphics.FillRectangle(b, e.ConnectedArea);
+        }
+    }
+    public class CustomMenuColor : ProfessionalColorTable
+    {
+        public override Color SeparatorDark
+        { get { return ColorScheme.MenuSeparatorColor; } }
+
+        public override Color SeparatorLight
+        { get { return ColorScheme.MenuSeparatorColor; } }
+    }
 }

--- a/LaserGRBL/MainForm.resx
+++ b/LaserGRBL/MainForm.resx
@@ -148,7 +148,7 @@
     <value>ConnectionForm</value>
   </data>
   <data name="&gt;&gt;ConnectionForm.Type" xml:space="preserve">
-    <value>LaserGRBL.ConnectLogForm, LaserGRBL, Version=5.1.0.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>LaserGRBL.ConnectLogForm, LaserGRBL, Version=5.6.0.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;ConnectionForm.Parent" xml:space="preserve">
     <value>splitContainer1.Panel1</value>
@@ -175,7 +175,7 @@
     <value>JogForm</value>
   </data>
   <data name="&gt;&gt;JogForm.Type" xml:space="preserve">
-    <value>LaserGRBL.JogForm, LaserGRBL, Version=5.1.0.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>LaserGRBL.JogForm, LaserGRBL, Version=5.6.0.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;JogForm.Parent" xml:space="preserve">
     <value>splitContainer1.Panel1</value>
@@ -217,7 +217,7 @@
     <value>PreviewForm</value>
   </data>
   <data name="&gt;&gt;PreviewForm.Type" xml:space="preserve">
-    <value>LaserGRBL.PreviewForm, LaserGRBL, Version=5.1.0.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>LaserGRBL.PreviewForm, LaserGRBL, Version=5.6.0.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;PreviewForm.Parent" xml:space="preserve">
     <value>splitContainer1.Panel2</value>
@@ -436,7 +436,7 @@
 </value>
   </data>
   <data name="MnConnect.Size" type="System.Drawing.Size, System.Drawing">
-    <value>180, 22</value>
+    <value>173, 22</value>
   </data>
   <data name="MnConnect.Text" xml:space="preserve">
     <value>&amp;Connect</value>
@@ -463,7 +463,7 @@
 </value>
   </data>
   <data name="MnDisconnect.Size" type="System.Drawing.Size, System.Drawing">
-    <value>180, 22</value>
+    <value>173, 22</value>
   </data>
   <data name="MnDisconnect.Text" xml:space="preserve">
     <value>&amp;Disconnect</value>
@@ -471,7 +471,7 @@
   <data name="MnWiFiDiscovery.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAIGNIUk0AAHolAACAgwAA+f8AAIDpAAB1
-        MAAA6mAAADqYAAAXb5JfxUYAAAAJcEhZcwAAAFkAAABZAaqdqYYAAAJYSURBVDhPpZJLaBNRGIWPiIX6
+        MAAA6mAAADqYAAAXb5JfxUYAAAAJcEhZcwAAAFgAAABYAXjaS2IAAAJYSURBVDhPpZJLaBNRGIWPiIX6
         KsVNcVFEN4UidaEudCu4UShWFHRZd4JrRXFjEUQFXelOKC6EdlOUdiOkeUwmmWZeFkqR5jWZzCRpMpOk
         sY2vXE+naCM+Fro4c+dxz/ef/58LIcR/aeviGRXqM+XCN1TqCRrqadS1ftQNoEl9VQFfAUpJwEkF6gY8
         pWbgmRJ8cxGe7vFewNdNaoyA/ej8DVDTgOo7aombTD7rJ1BVHxBaRs0QTDGFj9oR1P+YQH+BmvmSkLs0
@@ -486,7 +486,7 @@
 </value>
   </data>
   <data name="MnWiFiDiscovery.Size" type="System.Drawing.Size, System.Drawing">
-    <value>180, 22</value>
+    <value>173, 22</value>
   </data>
   <data name="MnWiFiDiscovery.Text" xml:space="preserve">
     <value>Wi-Fi Discovery</value>
@@ -495,7 +495,7 @@
     <value>False</value>
   </data>
   <data name="toolStripMenuItem2.Size" type="System.Drawing.Size, System.Drawing">
-    <value>177, 6</value>
+    <value>170, 6</value>
   </data>
   <data name="MnGrblReset.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
@@ -517,7 +517,7 @@
 </value>
   </data>
   <data name="MnGrblReset.Size" type="System.Drawing.Size, System.Drawing">
-    <value>180, 22</value>
+    <value>173, 22</value>
   </data>
   <data name="MnGrblReset.Text" xml:space="preserve">
     <value>&amp;Reset</value>
@@ -545,7 +545,7 @@
 </value>
   </data>
   <data name="MnGoHome.Size" type="System.Drawing.Size, System.Drawing">
-    <value>180, 22</value>
+    <value>173, 22</value>
   </data>
   <data name="MnGoHome.Text" xml:space="preserve">
     <value>&amp;Homing</value>
@@ -571,13 +571,13 @@
 </value>
   </data>
   <data name="MnUnlock.Size" type="System.Drawing.Size, System.Drawing">
-    <value>180, 22</value>
+    <value>173, 22</value>
   </data>
   <data name="MnUnlock.Text" xml:space="preserve">
     <value>&amp;Unlock</value>
   </data>
   <data name="toolStripSeparator1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>177, 6</value>
+    <value>170, 6</value>
   </data>
   <data name="MnGrblConfig.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
@@ -592,7 +592,7 @@
 </value>
   </data>
   <data name="MnGrblConfig.Size" type="System.Drawing.Size, System.Drawing">
-    <value>180, 22</value>
+    <value>173, 22</value>
   </data>
   <data name="MnGrblConfig.Text" xml:space="preserve">
     <value>Grbl Configuration</value>
@@ -616,7 +616,7 @@
 </value>
   </data>
   <data name="settingsToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
-    <value>180, 22</value>
+    <value>173, 22</value>
   </data>
   <data name="settingsToolStripMenuItem.Text" xml:space="preserve">
     <value>Settings</value>
@@ -624,7 +624,7 @@
   <data name="MnMaterialDB.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABGdBTUEAALGOfPtRkwAAACBjSFJNAAB6
-        JQAAgIMAAPn/AACA6QAAdTAAAOpgAAA6mAAAF2+SX8VGAAAACXBIWXMAAAsTAAALEwEAmpwYAAACrUlE
+        JQAAgIMAAPn/AACA6QAAdTAAAOpgAAA6mAAAF2+SX8VGAAAACXBIWXMAAAsSAAALEgHS3X78AAACrUlE
         QVQ4T6WO60uTYRjG3/+kz0F9iMjEMnClhZonEMdi1WxoHoZzMzE3DTwhKttCN0MqZROdluiMSkQdw8OG
         ZjrJaZ42Z21NrWnbxJ2eq/d1JH7wQ+ED1/PcXPf1/O6bAnAmnWr+j44LaftaWNFnDzf22OZrOtevngw1
         dC6zZL3rqzKtJVys+ERbJwClrfPDtCDtWGEa+OkDGTS5iWpwc1emnoqVa5dGjF8PyYoTGJ07gFRpQE1z
@@ -640,7 +640,7 @@
 </value>
   </data>
   <data name="MnMaterialDB.Size" type="System.Drawing.Size, System.Drawing">
-    <value>180, 22</value>
+    <value>173, 22</value>
   </data>
   <data name="MnMaterialDB.Text" xml:space="preserve">
     <value>Material DB</value>
@@ -648,7 +648,7 @@
   <data name="laserUsageStatsToolStripMenuItem.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAK
-        8AAACvABQqw0mAAAAAd0SU1FB9MCDQ8kHD5htUgAAAIbSURBVDhPzZDfS9NhFMYfmttcc+I2nVu/3OZ0
+        7wAACu8BfXaKSAAAAAd0SU1FB9MCDQ8kHD5htUgAAAIbSURBVDhPzZDfS9NhFMYfmttcc+I2nVu/3OZ0
         M9uP2tIsp6JZ+qUYmKsIGWSFUCB2IVHZTXdBf0jlzbIfEBR4GxhKglCwLHUEQfrFdHOb7elN35sgoksf
         OPDynvM55zwHO0f04XCmyfAq21a+nA3rZ+lFg0xBvGNrEf3rtaOGlBrQPGMtIjK1LTpxkLGaHxyOkoMh
         qhHjp5wXLoYQYwBjHGgscvAI2e8mu83cDGrWVzwISBxYDhse8X6cvBfjquLKpPfAVej3KBtxXy578dAm
@@ -661,13 +661,13 @@
 </value>
   </data>
   <data name="laserUsageStatsToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
-    <value>180, 22</value>
+    <value>173, 22</value>
   </data>
   <data name="laserUsageStatsToolStripMenuItem.Text" xml:space="preserve">
     <value>Laser Lifespan</value>
   </data>
   <data name="toolStripSeparator2.Size" type="System.Drawing.Size, System.Drawing">
-    <value>177, 6</value>
+    <value>170, 6</value>
   </data>
   <data name="MnHotkeys.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
@@ -687,18 +687,18 @@
 </value>
   </data>
   <data name="MnHotkeys.Size" type="System.Drawing.Size, System.Drawing">
-    <value>180, 22</value>
+    <value>173, 22</value>
   </data>
   <data name="MnHotkeys.Text" xml:space="preserve">
     <value>Hotkeys</value>
   </data>
   <data name="toolStripMenuItem6.Size" type="System.Drawing.Size, System.Drawing">
-    <value>177, 6</value>
+    <value>170, 6</value>
   </data>
   <data name="MnExit.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABGdBTUEAAJxAIA3kywAAACBjSFJNAABu
-        lQAAdA4AAPGBAACFRgAAZO0AAPeGAABJ4gAAHljF0QxvAAAACXBIWXMAAAsTAAALEwEAmpwYAAADS0lE
+        lQAAdA4AAPGBAACFRgAAZO0AAPeGAABJ4gAAHljF0QxvAAAACXBIWXMAAAsSAAALEgHS3X78AAADS0lE
         QVQ4T6WTWUwTYRDHt6WlLdCWbelWoBR6UUBrKSmHSLlSQJBDQUSKBuEBAkIIBBGFRETReCQKiUEaBW2C
         BS3BiA8IUjUeqDEeiYLXAxI1PmAMii1XGXeXVn33YTZfZr7/b+abfxYBgP8KRMKmk+HPRJAIsRCNCPTF
         JBwGIuUy3Fw1sacbIuN5MrRycZCCz3aXoSwanqcQNeICJYBFQaJlIsWw+eKz2wOX36Zq1bEynheFgAQS
@@ -717,7 +717,7 @@
 </value>
   </data>
   <data name="MnExit.Size" type="System.Drawing.Size, System.Drawing">
-    <value>180, 22</value>
+    <value>173, 22</value>
   </data>
   <data name="MnExit.Text" xml:space="preserve">
     <value>&amp;Exit</value>
@@ -731,7 +731,7 @@
   <data name="MnFileOpen.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABGdBTUEAAJxAIA3kywAAACBjSFJNAABu
-        lQAAdA4AAPGBAACFRgAAZO0AAPeGAABJ4gAAHljF0QxvAAAACXBIWXMAAAsTAAALEwEAmpwYAAADQElE
+        lQAAdA4AAPGBAACFRgAAZO0AAPeGAABJ4gAAHljF0QxvAAAACXBIWXMAAAsSAAALEgHS3X78AAADQElE
         QVQ4T3WTW0hTcRzHf12o16KnLrq5s013ph4921ymS/M6yyyzmuKclaJGN1pE2kP1UBRdhS4kUVBgF4LC
         ktIkIy1tF1dTj7u5uemmWallZhbhr7NZRkkPXw7n4fPhx//3/YFMIgOlMgMyM9fBlsKtUFpSCkmrkkAR
         p4AYaQzIZXKIjqIhRiafX1RUrBSLyNn8EB4ICX4g/xXExcYBzYJSWgpUBDX3/PmLJ0dGPn3PydmUGLR4
@@ -802,7 +802,7 @@
         XTesb3QPLh88M+QwdP6m681Lt7xuXbu94vbgcOjwnZHokdE77DtTd1PuvriXeW/h/sYH6AdFD6UeVjxS
         fNTws+7PbaOWo6fHXMf6Hwc/vj/OGn/2S8Yv7ycKnpCfVEyqTDZPmU2dmnafvvF05dOJZ+nPFmYKf5X+
         tfa5zvMffnP8rX82YnbiBf/Fp99LXsq/PPRq2aueuYC5R69TXy/MF72Rf3P4LeNt37vwd5MLWe+x7ys/
-        6H7o/ujz8cGn1E+f/gUDmPP8usTo0wAAAAlwSFlzAAALEwAACxMBAJqcGAAAA1JJREFUOE91k2tIU2EY
+        6H7o/ujz8cGn1E+f/gUDmPP8usTo0wAAAAlwSFlzAAALEgAACxIB0t1+/AAAA1JJREFUOE91k2tIU2EY
         x5/KCkWoyKwst7mzTXe23Ha2uUyXy9ucTrt7wTktS4NuqNVEK+hqWFJoBcMMMlSi6EMXLLtYZurcMnWZ
         p2YZlGn3m0QE7elsllHShx/vp//vfXjf/wNKuRLi4nSg1y+GrMxVkJuTC5GLIkEdpoYQRQiolCqQSSkI
         UaomZ2eviRMJyfG8AC4ICJ6b/wrCQsOAYoIKSgGSeRKPiopjpR8+fPq+fPlKjf9sPyA4AW7+K5hR5Qm+
@@ -974,7 +974,7 @@
   <data name="MnFileSend.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAK
-        8AAACvABQqw0mAAAAAd0SU1FB9MCGhU2KcxZSDgAAAIpSURBVDhPtdJfSNNRFAfws5L+DNrcJkGEL0aK
+        7wAACu8BfXaKSAAAAAd0SU1FB9MCGhU2KcxZSDgAAAIpSURBVDhPtdJfSNNRFAfws5L+DNrcJkGEL0aK
         abq2oZWUhRGVYFbDCh3OzOafbWxuWi1nrnItM5FNiAZR9JAvBZHpcoqxFKc2beiwKUQvSUlP0mQv5bcf
         cmEIYj7U5/Ge873ncLn075SSPuVm8gJVUIA0lMNO109ojJ+f/DaOzo9PIL239zd3iZvqSczKf5dgSlh4
         GXqOtsE7aBlqQPkLJfi1W77TNSphLWsT1YoWnk50oLHfAOPbUtR4lNB485HhSlwiM/XRbdrNWlcnNsX/
@@ -999,7 +999,7 @@
   <data name="MnStartFromPosition.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAL
-        EQAACxEBf2RfkQAAAAd0SU1FB9MKBhQLGasV+fsAAAMxSURBVDhPbZNrSJNRGMdfQzBJkTTzk4nTTMsb
+        EAAACxABrSO9dQAAAAd0SU1FB9MKBhQLGasV+fsAAAMxSURBVDhPbZNrSJNRGMdfQzBJkTTzk4nTTMsb
         hmgSmrPyktY+eIH64AL74sQPNqezzOaGCmKQqTPJZrQXF2YaCF3MdjGdipN5xwvLOZ1bTtStFDR9es4Y
         RJc//Hjfw3P+z3nOOc+h/pZYPFYhkQzbSkraeTj0LCnp5BUUtD1LSLh1GscuiBOZ94/EYqMzfpxqa790
         7ezsQ2trvzU/v+W9TDZ6qFYvQVaW4AXGgxGS5E/V12uENK2xikS9vTKZ5ofRaAWt1gRjY0aYmjKDUrkI
@@ -1175,7 +1175,7 @@
   <data name="MNFrench.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAIGNIUk0AAHolAACAgwAA+f8AAIDpAAB1
-        MAAA6mAAADqYAAAXb5JfxUYAAAAJcEhZcwAACxMAAAsTAQCanBgAAAFYSURBVDhPpdO/SwJhHMfxUyHv
+        MAAA6mAAADqYAAAXb5JfxUYAAAAJcEhZcwAACxIAAAsSAdLdfvwAAAFYSURBVDhPpdO/SwJhHMfxUyHv
         MDwzOk0QpSuzH2gOotOZRDkmkji0JUQpkUq5NOUUZGvtLYFba1tj4FJnRaQUBP0bn55H4TnusSHpAy+e
         6fveHgHAv9CNEW7COyJ6Q2+FqXT6Ajx+vUxhCL2lgaCmnaNabZnw+z4+Hag3+m93bYsGgjSgJpNnKBav
         kc1eMvw+8kXma+8I79omDaj9QCzWQC53hVSqyfDrreeZz8IuXpMZIxAOn0DTmohGG4hEBvi9xTeYLok8
@@ -1193,7 +1193,7 @@
   <data name="MNGerman.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAIGNIUk0AAHolAACAgwAA+f8AAIDpAAB1
-        MAAA6mAAADqYAAAXb5JfxUYAAAAJcEhZcwAACxMAAAsTAQCanBgAAAD8SURBVDhPpZO/asJQHEYDgiCt
+        MAAA6mAAADqYAAAXb5JfxUYAAAAJcEhZcwAACxIAAAsSAdLdfvwAAAD8SURBVDhPpZO/asJQHEYDgiCt
         CKKpSEVRkOJQCQ5NHRIyOiXkFfIEyYMJbo7diji1W/0L0pfI9PX3hXpFcbjRwCHcm++cLQaAu+BTFKpC
         Iyd06Bp1z/NwC3QZ6DiOgziOtUiSJHvToctAz7ZtRFGEIAjO8H0/4/KeWzp0s4BlWQjDEK7rasEtHRX4
         eRnh15ngMBzj8Pp+4vL8D7d0VOCrPcC+2cf2oaEFt3RUYPHUxc7sYlMyteCWjgqsPppIN22kq7oesqWj
@@ -1210,7 +1210,7 @@
   <data name="MNDanish.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAIGNIUk0AAHolAACAgwAA+f8AAIDpAAB1
-        MAAA6mAAADqYAAAXb5JfxUYAAAAJcEhZcwAACxMAAAsTAQCanBgAAAEHSURBVDhPpZOxasJQGIUDglAo
+        MAAA6mAAADqYAAAXb5JfxUYAAAAJcEhZcwAACxIAAAsSAdLdfvwAAAEHSURBVDhPpZOxasJQGIUDglAo
         FLSCUhQlVai69wEclC6iKG4WWnAvdBbsEwndHDvnFbSCyi1VyJb1957b5HqQDgke+Aic+39niyMiF4Gk
         NRlNPiFw4Dq5XX8kDOf8jYGLgfK2O5D9dGbhcA8O0w/zhQMXA+7mqSu/b++inl8NHDX+6xjcwoFrBtat
         jvy8TGTXGxo4Ucfgdt1qnwaCIAjP4weOHfB9P6zjB44dUEqFdfzAsQNflZp815qyLLoGTtQxuIVjBxZ3
@@ -1227,7 +1227,7 @@
   <data name="MNBrazilian.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAIGNIUk0AAHolAACAgwAA+f8AAIDpAAB1
-        MAAA6mAAADqYAAAXb5JfxUYAAAAJcEhZcwAACxMAAAsTAQCanBgAAAInSURBVDhPpZNPSNNhHIcHQmK1
+        MAAA6mAAADqYAAAXb5JfxUYAAAAJcEhZcwAACxIAAAsSAdLdfvwAAAInSURBVDhPpZNPSNNhHIcHQmK1
         BFchLcsS0YZUw0CCyoMmNcOYf3Lmn81IUOriTGu0nI7ApJ9NhTnmoTSY/TFTybyY5BQvRiaRRVkjgiCM
         AukPVIen9x00UTs0euE5fT/Pc3tVwH8h3ypBjCA2TKQjXdWG3H4HyzEKDHcaBU6Md1feJdKVgfijfXbq
         J66FsI13c368i6FXVxiea8E+0cU5f/eSjXSkKwMJhl4b1aNuSoeaKRhUsI05ePSmksDzKgKzVUwHKrGP
@@ -1249,7 +1249,7 @@
   <data name="russianToolStripMenuItem.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAIGNIUk0AAHolAACAgwAA+f8AAIDpAAB1
-        MAAA6mAAADqYAAAXb5JfxUYAAAAJcEhZcwAACxMAAAsTAQCanBgAAADYSURBVDhPpZM7CsJAFEUDAUEQ
+        MAAA6mAAADqYAAAXb5JfxUYAAAAJcEhZcwAACxIAAAsSAdLdfvwAAADYSURBVDhPpZM7CsJAFEUDAUEQ
         xU9UCIkhSgQbK3UF7kGtBK0s7V2KpaBFLAStUrqP6D4C17mSDCIWM/HBKd7wzunGAPAXnIKgJmhrQoeu
         YYlSrqHLgJfu2kOXgW66aw/ddyBJkvRJfejIwHATYrqLMN7eMPrge8/gLR0ZCFYH+Osz6ouTErylIwPO
         fA9nGaI6OyrBWzoycLd9PL0+4qarBG/pyEBk2Xi4AeJWRwne0pGBa8VC7PS0oJMFnEu5gTzQZaAiGAgm
@@ -1265,7 +1265,7 @@
   <data name="chinexeToolStripMenuItem.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAIGNIUk0AAHolAACAgwAA+f8AAIDpAAB1
-        MAAA6mAAADqYAAAXb5JfxUYAAAAJcEhZcwAACxMAAAsTAQCanBgAAAFmSURBVDhPpdO9SwJxGAfwAyEI
+        MAAA6mAAADqYAAAXb5JfxUYAAAAJcEhZcwAACxIAAAsSAdLdfvwAAAFmSURBVDhPpdO9SwJxGAfwAyEI
         gqAXksK0zqSUEkJqKDB78ahBUzuXIMGkXWpNdKuhpT+gtTVoa2xrbQw8pVMSX4haG749z70Z0uDVwYd7
         nrvf98stJwD4F74GyAhx2sQZzgrj9WQamjhJkIM0OpdJfWbm+x6c5QJPLZ5C56qIz9uCdm8VS2gVStqu
         zef6ztrGnTOc5QJRjcbwcZPHV/sQ79cZvGWOdUdZg7EbmvkzqHsxLhC1gkpYQvM0h85FAo1cCrVdmT5d
@@ -1283,7 +1283,7 @@
   <data name="traditionalChineseToolStripMenuItem.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAIGNIUk0AAHolAACAgwAA+f8AAIDpAAB1
-        MAAA6mAAADqYAAAXb5JfxUYAAAAJcEhZcwAACxMAAAsTAQCanBgAAAFmSURBVDhPpdO9SwJxGAfwAyEI
+        MAAA6mAAADqYAAAXb5JfxUYAAAAJcEhZcwAACxIAAAsSAdLdfvwAAAFmSURBVDhPpdO9SwJxGAfwAyEI
         gqAXksK0zqSUEkJqKDB78ahBUzuXIMGkXWpNdKuhpT+gtTVoa2xrbQw8pVMSX4haG749z70Z0uDVwYd7
         nrvf98stJwD4F74GyAhx2sQZzgrj9WQamjhJkIM0OpdJfWbm+x6c5QJPLZ5C56qIz9uCdm8VS2gVStqu
         zef6ztrGnTOc5QJRjcbwcZPHV/sQ79cZvGWOdUdZg7EbmvkzqHsxLhC1gkpYQvM0h85FAo1cCrVdmT5d
@@ -1301,7 +1301,7 @@
   <data name="slovakianToolStripMenuItem.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAIGNIUk0AAHolAACAgwAA+f8AAIDpAAB1
-        MAAA6mAAADqYAAAXb5JfxUYAAAAJcEhZcwAACxMAAAsTAQCanBgAAAFySURBVDhPpZPfK0NhGMdPrdRC
+        MAAA6mAAADqYAAAXb5JfxUYAAAAJcEhZcwAACxIAAAsSAdLdfvwAAAFySURBVDhPpZPfK0NhGMdPrdRC
         09oPWdvZr7aFJiQzc9gkbsyNUFZ2cMP/IMmFUmPIkrWTEldcELWVSzf8E6O4onahrdTq6zzHcU6NC4en
         PvW+T+/nc/cyAP4FTZ2IUaRZI+SQy5jF0p+GXAo45bvmIZcCHvmueciVAtVqVV4BLwvzKKVSKKXTeOV5
         eft9yFECAS4DbvIUM8vnKM3NopLPo1Io4I1PYHrpDMERAcGxnAI3dYJAeFcNsD3baIkcIjwhoBwNoby2
@@ -1320,7 +1320,7 @@
   <data name="hungarianToolStripMenuItem.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAIGNIUk0AAHolAACAgwAA+f8AAIDpAAB1
-        MAAA6mAAADqYAAAXb5JfxUYAAAAJcEhZcwAACxMAAAsTAQCanBgAAADoSURBVDhPpZPLCwFRFIeHKY+S
+        MAAA6mAAADqYAAAXb5JfxUYAAAAJcEhZcwAACxIAAAsSAdLdfvwAAADoSURBVDhPpZPLCwFRFIeHKY+S
         0ZSyUcpONmw889pIFmRD2WHDjhWLKfKHzsJjEjW72R73N8YVWdzLqa+p0/m+xa1RiOgvMAGGzkhIAgeu
         Ej81u/QLcBFIHWttui7XQtxWG/cLBy4C6UOxRZfpgs790Tu94YOPPW7hwHUDZq5K1mBMx3pHCNyaucor
         4DgOe1C5gcMDtm17a/GBwwOWZXlr8YHDA9qqRPq+RUGjJARu4fBAaJ6n2K5BIaMshHvLHB7wz7IU3dal
@@ -1336,7 +1336,7 @@
   <data name="czechToolStripMenuItem.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAIGNIUk0AAHolAACAgwAA+f8AAIDpAAB1
-        MAAA6mAAADqYAAAXb5JfxUYAAAAJcEhZcwAACxMAAAsTAQCanBgAAAGFSURBVDhPpZM9SAJhHIcloTCF
+        MAAA6mAAADqYAAAXb5JfxUYAAAAJcEhZcwAACxIAAAsSAdLdfvwAAAGFSURBVDhPpZM9SAJhHIcloTCF
         RMsMNRVPw6zTM0KFyIZAGoJSB4doaQqiIYwgWiSHyJCIzCER+qAhjKKPoZaiGlqFplKLlqagGoTI+HWv
         SAdpovSDhxvu/zzbywPwL8hqWSQs8iohDnF5TYHINV7fP9hgdSMuCWh6PXEE165w9/hS+FXZiEsCOodv
         A2Mzh3CP72Ln+Bafua/CSfkRNx+wutfhmdyDc2QLTm8cE/OneHp+K5yVXi6X4wLGgQico9uwDMdgHoqB
@@ -1355,7 +1355,7 @@
   <data name="polishToolStripMenuItem.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAIGNIUk0AAHolAACAgwAA+f8AAIDpAAB1
-        MAAA6mAAADqYAAAXb5JfxUYAAAAJcEhZcwAACxMAAAsTAQCanBgAAAC+SURBVDhPpZPBCoJAFEUHhCCI
+        MAAA6mAAADqYAAAXb5JfxUYAAAAJcEhZcwAACxIAAAsSAdLdfvwAAAC+SURBVDhPpZPBCoJAFEUHhCCI
         hMgSRJOSIikIWvTfgbuW7Vr2AWM/4Uq4vRvTrFq8sQtn4fDO2WkA/AU3EmZCGggduiaR0qDRZaB038Gj
         y8DGfQeP7ifQ97170o+OD3Rd5571o+MDz+MZr/0JNlur4C0dH3hUNdrqAJuWKnhLxwfurJY72EWhgrd0
         fOCWZGiLLexypYK3dHygiRPYvAqCzjeQX6dzDIEuA7FQC5dA6NA1kTAWJoHQiX7+onpg3gbAKhNU+oiX
@@ -1371,7 +1371,7 @@
   <data name="greekToolStripMenuItem.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAIGNIUk0AAHolAACAgwAA+f8AAIDpAAB1
-        MAAA6mAAADqYAAAXb5JfxUYAAAAJcEhZcwAACxMAAAsTAQCanBgAAAEcSURBVDhPY/j//z9FGATYgFgI
+        MAAA6mAAADqYAAAXb5JfxUYAAAAJcEhZcwAACxIAAAsSAdLdfvwAAAEcSURBVDhPY/j//z9FGATYgFgI
         iCVIxCA9IL0Moo4z9v13nLgLaCAEOE7e/R8sNm0vXgzSCzJAwa5/5//ClSeh2v+D2UXrzvw/fOsJBj4C
         pdeduQkyQAFkgDJUH8kApBdswJ8/f6BCqMBzzkGsOHrZ8f/Wk3ciDNCoX/PfrmsbVNv//3oNG/4bdW6F
         8rCDb9++IQxQrl/5X6p2LVTq/3/uspX/+WvW/hcHGiTRiInVgIZrtaxBGPD8+XOoVuIBSA/cAMni2f9l
@@ -1388,7 +1388,7 @@
   <data name="turkishToolStripMenuItem.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAIGNIUk0AAHolAACAgwAA+f8AAIDpAAB1
-        MAAA6mAAADqYAAAXb5JfxUYAAAAJcEhZcwAACxMAAAsTAQCanBgAAAG2SURBVDhPpZOxSwJhGIeFICiK
+        MAAA6mAAADqYAAAXb5JfxUYAAAAJcEhZcwAACxIAAAsSAdLdfvwAAAG2SURBVDhPpZOxSwJhGIeFICiK
         IJLKNMXSQAQFB4ccNMqCEhKhwUEj2hLEzUR0ChoiDf8C/wCHgrbGtsZWudM67VIzsxzt1/d+0VFU0NHB
         w/sd3PN8x3ecBsC/oGuQMc6YUgk55Gq09VAItUAANNVALgVM9c1NtFIpPGQyfDaTSbTSaX7/jWyWT3LI
         pcBcbX0djVgMd+EwWvv76BQKfMqRCORoFPL29heaiQTIIZcHqsvLkLe28FQsot/r4aVUQvvwEPe7u6ht
@@ -1408,7 +1408,7 @@
   <data name="romanianToolStripMenuItem.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAIGNIUk0AAHolAACAgwAA+f8AAIDpAAB1
-        MAAA6mAAADqYAAAXb5JfxUYAAAAJcEhZcwAACxMAAAsTAQCanBgAAAGASURBVDhPpdNNKMNhAMfxscKi
+        MAAA6mAAADqYAAAXb5JfxUYAAAAJcEhZcwAACxIAAAsSAdLdfvwAAAGASURBVDhPpdNNKMNhAMfxscKi
         /Rl7ifDPlpeFGcbKmpdILLUNpTQtbho15YIoF69JuXFQcuJGLlIubtxc1d+KtZK2TK4/zzPz/PeYg+Wp
         T8/p9+25PAoA/0JPDqEhDBmiG7pVaLv9x/gJ8X5OeGg4Dd3SgOj0HSG4fsnBxzzndWE5aSVxhwfdNCDS
         gNE+doippXO4AycM3keJkaRRRMb9zMtMEM99LhowJgJW7z68s6fonDhiEO/jhF0eJuKbRMjZKwdqB/bg
@@ -1427,7 +1427,7 @@
   <data name="dutchToolStripMenuItem.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAIGNIUk0AAHolAACAgwAA+f8AAIDpAAB1
-        MAAA6mAAADqYAAAXb5JfxUYAAAAJcEhZcwAACxMAAAsTAQCanBgAAADkSURBVDhPpZPNCwFRFEcnUzKl
+        MAAA6mAAADqYAAAXb5JfxUYAAAAJcEhZcwAACxIAAAsSAdLdfvwAAADkSURBVDhPpZPNCwFRFEcnUzKl
         fKVslLCykpKsLchmIrKjKDtJsaRYKvyLimmEmt1sr/ubxhNZvMet09Sde85iajQi+gtMkIkzKUXgwNWS
         VrtHvwAXgczZ7NBttZbivtp4TzhwEcidmiZdZ3OyB6N3+j4fe9zCgesFjrUGXYZjslpdKXB7rNVfAdd1
         +YOqDRwRcBzHX8sPHBGwbdtfyw8cEYiWlpSoHihU3EqBWzgiYBQWFKvsyeCXMni37IiAnp9SpLxTAs4z
@@ -1443,7 +1443,7 @@
   <data name="ukrainianToolStripMenuItem.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAIGNIUk0AAHolAACAgwAA+f8AAIDpAAB1
-        MAAA6mAAADqYAAAXb5JfxUYAAAAJcEhZcwAACxMAAAsTAQCanBgAAAETSURBVDhPY/j//z9FGATYgFgI
+        MAAA6mAAADqYAAAXb5JfxUYAAAAJcEhZcwAACxIAAAsSAdLdfvwAAAETSURBVDhPY/j//z9FGATYgFgI
         iCVIxCA9IL0Mou7T9/wnB4P0ggxQcJ6663/pxrNE4bJNEBqkB6QXZICy3aSd/zNWnvgfOu8gCg6BYnRx
         kFqQHpBesAEWPZv/h88/9N916m6iMEgtSA/cAP3WtUCJPf/Nerf9N+1BYHQ+DIPUgvTADXj/SO3//49K
         //9/ECYOA9WC9MANeH5LFigIxB8EicNAtSA9cAPuXxL7//+9JBDzQzEfEhvGR8ZS/0F64AZcPwUU/CAB
@@ -1550,7 +1550,7 @@
   <data name="orturSupportGroupToolStripMenuItem.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAO
-        xAAADsQBlSsOGwAABZ1JREFUWEfN1llTFFcUB/D5AKlKHlKVPOQT5FFUXCIokgRlG2EGmBlkBtxwFAYV
+        wwAADsMBx2+oZAAABZ1JREFUWEfN1llTFFcUB/D5AKlKHlKVPOQT5FFUXCIokgRlG2EGmBlkBtxwFAYV
         FAFpVEAkwEUFFzSIgCsIAgISYMBhBxmIoLhUYtQqt5SpJKWxEpWTc7tvT3fPAviUnKrz2r9/33tP31b9
         b8qY/+Dz2Lw7Sabc25wpd5IzZU9yMdk3hd43zkXzbeeis+ycPusGp88c5jsqYxC7n4tIo93LaVJt2N2c
         Zmc3F5Zsxe7g1Nt/wL7GhSRd44KTWhKCNjZ+ylih1ufd+yL2wNTz2AO3ITb3Nphyb4EpZxKM2ROAASBm
@@ -1630,7 +1630,7 @@
         8m2v29fvrLwzMBQydHc4cnjkLvvu5L2key/vZ9yff7DpIfph4SOpR+WPlR7X/aj3Y+uI5ciZUdfRvidB
         Tx6Mscae/5T+04fx/Kfkp+UTqhONk2aTp6fcp24+W/1s/Hnq8/npgp+lf65+ofviu18cf+mbWTUz/pL/
         cuHX4lfyr468Xva6e9Z/9vGb5Dfzc4Vv5d8efcd41/s+7P3EfOYH7IeKj3ofuz55f3q4kLyw8Bv3hPP7
-        LAE+RQAAAAlwSFlzAAALEwAACxMBAJqcGAAAA1lJREFUOE9lUmlsy2EYf9//1X+7tjt1B1tW6472b223
+        LAE+RQAAAAlwSFlzAAALEgAACxIB0t1+/AAAA1lJREFUOE9lUmlsy2EYf9//1X+7tjt1B1tW6472b223
         dp0NE3NMyBgLNjN3bAibxtwxs4khiNFI3OKDUSyORF0RIbFGWCdbMHYYX8xmFTHX5vW8c4X9kufL8/x+
         z43MZvM/ZjT9NFuCWUyxJalTU4b7gqmsFgtvNBoH8AdgEIMis/zQ6tII9vIB+9I7hxxVN0o3rD2ckz11
         RVRkhBFjxPyi/gue42TJ1oSMQznjHzxMZL6/TMbkbc1x8vHLV9Ld3d3X2NDw9shBh2vk8KRMjP5LIsoE
@@ -1684,7 +1684,7 @@
   <data name="youtubeChannelToolStripMenuItem.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAIGNIUk0AAHolAACAgwAA+f8AAIDpAAB1
-        MAAA6mAAADqYAAAXb5JfxUYAAAAJcEhZcwAACxMAAAsTAQCanBgAAAKJSURBVDhPpVPZTxpBHFYDGg9Q
+        MAAA6mAAADqYAAAXb5JfxUYAAAAJcEhZcwAACxIAAAsSAdLdfvwAAAKJSURBVDhPpVPZTxpBHFYDGg9Q
         IRrEq54YEQMaj2iMDeAR9MUzEB9M9P+BJ/8KbJs+qLi2olVrNWITkWoUqPewBqWJfcAa/PrbtbB9bif5
         dmb2O+Y3M7tpAP4L4mPTbHZdT03FeIeDjzgcTACz20VE/iA5v7Xb+RvSblgsrlQAm5gAHA48jY4iQcDI
         CJ4nJ8VxYnz8BWNjeKb+iTjY7bgRPMmAy+HhyK+hIdwPDiJG/YXJhKhej582G+4FDAwgJnCEaH8/BO2l
@@ -1754,7 +1754,7 @@
         XTesb3QPLh88M+QwdP6m681Lt7xuXbu94vbgcOjwnZHokdE77DtTd1PuvriXeW/h/sYH6AdFD6UeVjxS
         fNTws+7PbaOWo6fHXMf6Hwc/vj/OGn/2S8Yv7ycKnpCfVEyqTDZPmU2dmnafvvF05dOJZ+nPFmYKf5X+
         tfa5zvMffnP8rX82YnbiBf/Fp99LXsq/PPRq2aueuYC5R69TXy/MF72Rf3P4LeNt37vwd5MLWe+x7ys/
-        6H7o/ujz8cGn1E+f/gUDmPP8usTo0wAAAAlwSFlzAAALEwAACxMBAJqcGAAABZdJREFUWEfFl1tMVFcU
+        6H7o/ujz8cGn1E+f/gUDmPP8usTo0wAAAAlwSFlzAAALEgAACxIB0t1+/AAABZdJREFUWEfFl1tMVFcU
         hkfTpkkfGpOmbRpN06R960Of25f20bRNGp9aQKltrDVWQAEZkIuAl6IiKjrAADOMdYR6qVipiKAVuViq
         4oVG6zAzaLhVYGYYhmHu079r7TNnAD0O8yKS/GzOPmev/e1/r3XORgXghUqxczE170J3qm1Z7cnWPdRO
         1p5oddfMyqOtb/7niOFs+V6N8UOVSrWUtITHVB5r+qDS+PsBvs/PyWN4PMVyUn+purjsjciYpXPnY0X/
@@ -1820,7 +1820,7 @@
   <data name="MnConfigureOrturWiFi.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAIGNIUk0AAHolAACAgwAA+f8AAIDpAAB1
-        MAAA6mAAADqYAAAXb5JfxUYAAAAJcEhZcwAAAFkAAABZAaqdqYYAAAJYSURBVDhPpZJLaBNRGIWPiIX6
+        MAAA6mAAADqYAAAXb5JfxUYAAAAJcEhZcwAAAFgAAABYAXjaS2IAAAJYSURBVDhPpZJLaBNRGIWPiIX6
         KsVNcVFEN4UidaEudCu4UShWFHRZd4JrRXFjEUQFXelOKC6EdlOUdiOkeUwmmWZeFkqR5jWZzCRpMpOk
         sY2vXE+naCM+Fro4c+dxz/ef/58LIcR/aeviGRXqM+XCN1TqCRrqadS1ftQNoEl9VQFfAUpJwEkF6gY8
         pWbgmRJ8cxGe7vFewNdNaoyA/ej8DVDTgOo7aombTD7rJ1BVHxBaRs0QTDGFj9oR1P+YQH+BmvmSkLs0
@@ -1914,7 +1914,7 @@
   <data name="activateExtendedLogToolStripMenuItem.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAO
-        wwAADsMBx2+oZAAAArJJREFUOE9jIBYYR9YL6wbW7NMPbTyvF9pwXieo5pheYL0oVBoV6EROE4Ay4UA3
+        wgAADsIBFShKgAAAArJJREFUOE9jIBYYR9YL6wbW7NMPbTyvF9pwXieo5pheYL0oVBoV6EROE4Ay4UA3
         sDpEN6h6p25gha8WEAP5m4AGBkOlIQCowFYvuH6/fmjTAb2Qun3awdWWUCkGvaC6GEWP0sOiNpndIKzo
         XnJAJ6QuCirNwKAdUK2kG1RzSze41kPNt5RHL6jRB2jLTc2gajmQvIZfxdTYxpX/c3rW/MzuXvMzoWXV
         fy3/qqlgzSCgG1RbDdTQDeWCAdDAiUBXlYLYiu5FMzZffPP/6d///x///v9/7+3P/9W8SmeCFYIAUGE7
@@ -1941,7 +1941,7 @@
   <data name="helpOnLineToolStripMenuItem.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABGdBTUEAAJxAIA3kywAAACBjSFJNAABu
-        lQAAdA4AAPGBAACFRgAAZO0AAPeGAABJ4gAAHljF0QxvAAAACXBIWXMAAAsTAAALEwEAmpwYAAADm0lE
+        lQAAdA4AAPGBAACFRgAAZO0AAPeGAABJ4gAAHljF0QxvAAAACXBIWXMAAAsSAAALEgHS3X78AAADm0lE
         QVQ4T1VTa0yTZxh9d5OfbkRI8FLKpbrEZWJLS102Ycl+zVlk082pGSOGZXHZRYNLxprQIdTS2lLaMqBQ
         CqmDQkIKSAxS+WihtqXlIqjYdhUoLbeKwv4si8s8e7+yZdmP53u+H9855znPdx6SnZFJTn18mnzz3SUi
         FonJ5bLLImtnp5xhmJtuj9c1PMzcqjfo1aXnS9/OP1pAMtO5CQyPFtsTjw8/OkUufPX1zo7r1/WB+aXf
@@ -1996,7 +1996,7 @@
   <data name="facebookCommunityToolStripMenuItem.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAO
-        xAAADsQBlSsOGwAABZ1JREFUWEfN1llTFFcUB/D5AKlKHlKVPOQT5FFUXCIokgRlG2EGmBlkBtxwFAYV
+        wwAADsMBx2+oZAAABZ1JREFUWEfN1llTFFcUB/D5AKlKHlKVPOQT5FFUXCIokgRlG2EGmBlkBtxwFAYV
         FAFpVEAkwEUFFzSIgCsIAgISYMBhBxmIoLhUYtQqt5SpJKWxEpWTc7tvT3fPAviUnKrz2r9/33tP31b9
         b8qY/+Dz2Lw7Sabc25wpd5IzZU9yMdk3hd43zkXzbeeis+ycPusGp88c5jsqYxC7n4tIo93LaVJt2N2c
         Zmc3F5Zsxe7g1Nt/wL7GhSRd44KTWhKCNjZ+ylih1ufd+yL2wNTz2AO3ITb3Nphyb4EpZxKM2ROAASBm
@@ -2035,7 +2035,7 @@
   <data name="donateToolStripMenuItem.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAG
-        tgAABrYB8zSmegAAABl0RVh0U29mdHdhcmUAd3d3Lmlua3NjYXBlLm9yZ5vuPBoAAAGESURBVDhPY0AG
+        tQAABrUBXo2HFwAAABl0RVh0U29mdHdhcmUAd3d3Lmlua3NjYXBlLm9yZ5vuPBoAAAGESURBVDhPY0AG
         2toNbCrWDX4qNo2hKNiy0V3DpkENqgw3AClWtW74jxPbNNxSsmtWhSrHBEBFTRia0LCaTcMlqHJMAHT+
         NlQN9WgYaIB1w2+ockygalV/H6ZZxbzqv5JuKhpO/69iUvBCYs5NM6gWZNDABDT9F9wAkyIsBqT+V7Qu
         +y8+8+onlUm32aEaIQDoNyWYZhBWNszBaoBM7qr/4rOv/xedc1UFqhUCgLZ7IRugpJuGoVk+oAesGYyn
@@ -2054,7 +2054,7 @@
   <data name="licenseToolStripMenuItem.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAK
-        8AAACvABQqw0mAAAAAd0SU1FB9MDBhERIE/mK7IAAAI8SURBVDhPrZFNbxJRFIZv/PgNykbd6c7Elf4B
+        7wAACu8BfXaKSAAAAAd0SU1FB9MDBhERIE/mK7IAAAI8SURBVDhPrZFNbxJRFIZv/PgNykbd6c7Elf4B
         N41xrcatiV20CqSBKhObkNCFoU1LTRzaNMQSsLGh1kKDhEgNDQVrCqQGkS+ZDB+1lRRKylBgXu/AddHo
         gkXf5GbunDnPe+acQ05VHPflnNcrPHC5Up5AIF/Z2MjLgUBaXl2NV+bmfO7paff99fWPZ1n6SaVSuBYM
         /o6J4hH+p3od2Noqguc/RB2OT1cZ1lM4fHRlc7Oyy3Ihy0BD6oDcmge5OY9KBdjfB4pFoFAAZmffly0W

--- a/LaserGRBL/PreviewForm.cs
+++ b/LaserGRBL/PreviewForm.cs
@@ -146,7 +146,7 @@ namespace LaserGRBL
 				ContextMenuStrip = cms;
 			}
 
-			internal bool PositionUnlocked
+			private bool PositionUnlocked
 			{
 				get
 				{

--- a/LaserGRBL/PreviewForm.cs
+++ b/LaserGRBL/PreviewForm.cs
@@ -139,7 +139,6 @@ namespace LaserGRBL
 				this.Caption = cb.Caption;
 				tt.SetToolTip(this, cb.ToolTip);
 
-
 				cms = new ContextMenuStrip();
 				cms.Items.Add(Strings.CustomButtonRemove, null, RemoveButton_Click);
 				cms.Items.Add(Strings.CustomButtonEdit, null, EditButton_Click);
@@ -147,7 +146,7 @@ namespace LaserGRBL
 				ContextMenuStrip = cms;
 			}
 
-			private bool PositionUnlocked
+			internal bool PositionUnlocked
 			{
 				get
 				{

--- a/LaserGRBL/UrlManager.cs
+++ b/LaserGRBL/UrlManager.cs
@@ -19,5 +19,9 @@ namespace LaserGRBL
 		public static string TelegramServiceKey = null;
 		public static string UpdateMaterialDB = null;
 		public static string DownloadMaterialDB = null;
-	}
+
+		// we just use a non-filled-in URL here
+		public static string LaserStatistics = null;
+
+    }
 }


### PR DESCRIPTION
hi arkypita!

I recently bought a laser engraver and found your software, which performs excellently!

As a programmer, I was overjoyed to find your project is open source and written in C#,
one of my favourite languages.  
So, I decided to start contributing, if you are interested in my additions/changes.

One thing I missed, is the ability to assign keyboard shortcuts to custom buttons 'by name', e.g. the 'Blink' button to preview where the laser will be aimed at the object, a very handy feature to have on the keyboard while staring through the dark laser glasses. (I have rather poor vision and need to swap out my regular glasses for the darkened ones, and then I don't see my screen very well... so keyboard shortcuts are essential to me ;-).

I discovered it was already possible to assign a keyboard shortcut to a custom button 'by number', but not 'by name' yet.
So I thought I would chip in my two cents to improve on that.

I made a few changes:

By providing a 'hotKeyName' to the CustomButton (an extra field on such a button that shows up in the Hotkey form),
I was able to differentiate the HotKeyManager between the built-in Actions (enum) and the customButton actions (by this string 'HotKeyName').
When a action is built-in, it uses this regular Actions enum, but when it's an action bound to a customButton, its Actions enum is 'None', and the HotKeyName is filled-in instead.  This is the main differentiation really.

(note: I was at first tempted to simply use the Tooltip string for recognition, but that would maybe be a bit less clear to the user, to abuse that string.. so I added the 'HotKeyName' to CustomButton.  It's a matter of taste I guess.)

----

After throwing away my old settings file from the typical Windows C://users/...../AppData/LaserGRBL folder, and letting LaserGRBL re-generate the hotkey table so I had a clean settings file, I added some custom buttons to test it.  
The HotKey manager form now displays built-in actions as well as customButton actions nicely in the datagridview by name, saves them to settings as usual, etc.

I removed the provisions of the 'numbered' customButtons in the HotKeyManager's Actions enum, since they are now no longer needed, and got extended to a (hopefully ;-) more convenient solution, 'by name'.

---

While making this pull request, I noticed that I probably use a different Visual Studio version than you (VS2022), and also the auto-formatter of Visual Studio changed a bit more whitespace than needed, which clutters the diff of this pull-request a bit... argh!  
I apologize for that, and hope you can see through it.
There's actually not that many in-depth changes if you look at the files side-by-side and don't mind the things Visual Studio changed 'automatically', the whitespace, the auto-generated WinForms files.   This pull-request view looks far more dramatic than it actually is ;-)

The classes I adjusted, I also cleaned up a little, but that's just optional and a matter of taste, of course.  e.g. the lambda getter features of modern C#.  you might as well disregard those changes of course.  It was just for my reading clarity that I cleaned up in some places.

---

I plan to make all kinds of additions in the future, but let's say this is a little starter for warming up to your code-base and getting to know the project ;-)

kind regards,
loki of mute

![CustomButton_changes_001](https://github.com/arkypita/LaserGRBL/assets/2388174/82e93b0c-8e70-4b1c-a5ad-8ba55f8a0fb4)
![HotKeyManager_changes_001](https://github.com/arkypita/LaserGRBL/assets/2388174/022f67cb-e731-4b96-b5d1-9f3524e1c93e)
