### PR TITLE
Fix wrong DPI from EXIF

### DIFF
--- a/LaserGRBL/RasterConverter/ImageProcessor.cs
+++ b/LaserGRBL/RasterConverter/ImageProcessor.cs
@@ -122,7 +122,7 @@ namespace LaserGRBL.RasterConverter
             //http://stackoverflow.com/questions/2016406/converting-bitmap-pixelformats-in-c-sharp
             using (Bitmap loadedBmp = new Bitmap(fileName))
             {
-                mFileDPI = (int)loadedBmp.HorizontalResolution;
+                mFileDPI = (int) Math.Round(loadedBmp.HorizontalResolution);
                 mFileResolution = loadedBmp.Size;
 
                 using (Bitmap tmpBmp = new Bitmap(loadedBmp))


### PR DESCRIPTION
Fix #2376.

On some platforms, like Wine, DPI count is truncated in the cast from float to integer, so the value is interpreted 1 count lower than it really is. Rounding before the cast fixes this issue.