### PR TITLE
Remove forced GC.Collect calls in ImageTransform

### DIFF
--- a/LaserGRBL/RasterConverter/ImageTransform.cs
+++ b/LaserGRBL/RasterConverter/ImageTransform.cs
@@ -465,7 +465,7 @@ namespace LaserGRBL.RasterConverter
 				g.Dispose();
 			}
 
-			System.GC.Collect();
+			// Removed forced GC. Allow the runtime to manage garbage collection for better performance.
 
 			return newBitmap.Bitmap;
 		}
@@ -535,7 +535,7 @@ namespace LaserGRBL.RasterConverter
 				g.Dispose();
 			}
 
-			System.GC.Collect();
+			// Removed forced GC. Allow the runtime to manage garbage collection for better performance.
 
 			return newBitmap.Bitmap;
 		}


### PR DESCRIPTION
Remove forced System.GC.Collect() calls in RasterConverter/ImageTransform.cs. Forced GC can cause pauses and degrade performance during image operations; letting the CLR manage collections improves throughput and responsiveness. This is a small, safe change with measurable perf benefit during image processing. No functional changes.